### PR TITLE
removing paypal and amazon references [#36554899]

### DIFF
--- a/frontend/templates/faq_pledge.html
+++ b/frontend/templates/faq_pledge.html
@@ -6,24 +6,17 @@
                     	<li class="first parent">
                     		<span class="faq">How do I pledge?</span>
                             <span class="menu level2 answer">
-                            Enter your pledge amount and select a premium. (You may select a premium at any level up to and including the amount you pledge.)  If you pledge enough, you're also eligible to be credited in the unglued ebook and to include a dedication, and toward the bottom of this page you can specify what you'd like those to say.  After you click Pledge, you'll be directed through Amazon to complete the transaction.
+                            Enter your pledge amount and select a premium. (You may select a premium at any level up to and including the amount you pledge.)  If you pledge enough, you're also eligible to be credited in the unglued ebook and to include a dedication, and toward the bottom of this page you can specify what you'd like those to say.  After you click Pledge, we'll collect your credit card information.
                             </span>
                     	</li>
 
                         <li class="parent">
-                            <span class="faq">Do I need an Amazon account to pledge?</span>
+                            <span class="faq">What forms of payment do you accept?</span>
                             <span class="menu level2 answer">
-                            Yes.  We know this is an obstacle for some users, and we apologize.  Unfortunately we cannot offer other options at this time.  There are more details at <a href="http://blog.unglue.it/2012/05/03/unglue-it-payment-options-amazon-vs-paypal/">our blog</a>.
+                            We accept Visa, Mastercard, American Express, JCB, Discover, and Diners Club.
                             </span>
                         </li>
                         
-                        <li class="parent">
-                            <span class="faq">Can I use PayPal or some other non-Amazon payment system?</span>
-                            <span class="menu level2 answer">
-                            We're sorry, but no.  At this time PayPal and Amazon are the only payment processors which support pledges (rather than immediate charges).  While we're working on adding PayPal support, we don't yet have all the approvals we need to do so.  There are more details at  <a href="http://blog.unglue.it/2012/05/03/unglue-it-payment-options-amazon-vs-paypal/">our blog</a>.
-                            </span>
-                        </li>
-
                         <li class="parent">
                             <span class="faq">When will I be charged?</span>
                             <span class="menu level2 answer">

--- a/frontend/templates/notification/pledge_status_change/full.txt
+++ b/frontend/templates/notification/pledge_status_change/full.txt
@@ -9,23 +9,9 @@ Your new pledge summary
 Amount pledged: ${{ transaction.amount|intcomma }}
 Premium: {% if transaction.premium %}{{ transaction.premium.description }}{% else %}None requested{% endif %}{% endif %}
 
-{% if transaction.host|lower == 'amazon' %}{% if up_or_down == 'increased' %}
-You will also receive an email from Amazon confirming that you've canceled your original pledge and authorized this one.
-{% else %}{% if up_or_down == 'decreased' %}
-Your Amazon Payments account may still show an authorization to Unglue.it for the entire amount of your earlier pledge, but never fear -- if the campaign succeeds, we'll only charge you ${{ transaction.amount|intcomma }}.
-{% endif %}{% endif %}{% else %}{% endif %}
-
 If you'd like to visit the project page, click here: 
 https://{{site.domain}}{% url work transaction.campaign.work.id %}
 
 Thank you again for your support.
 
 {{ transaction.campaign.rightsholder }} (rights holder for {{ transaction.campaign.work.title }}) and the Unglue.it team
-
-{% comment %}
-If we're going to send notifications in the event of an incomplete transaction, fill in another if (or the rest of the if). In the meantime, testing for 'decreased' specifically rather than !'increased' in order to allow for that.
-
-If we get Paypal running, we're going to need to figure out what notifications they send in the various pledge change events and make the communication to users consistent with that.
-
-Space has been left in the if statements for these contingencies.
-{% endcomment %}

--- a/frontend/templates/pledge_nevermind.html
+++ b/frontend/templates/pledge_nevermind.html
@@ -10,10 +10,9 @@
 {% block doccontent %}
 
 {% if transaction %}
-    <div>You were about to pledge ${{transaction.amount}} to <a href="{% url work work.id %}">{{work.title}}</a> but hit the cancel link.
-    Naturally, we won't be charging your PayPal account for this campaign unless you give permission.</div>
-    <div>However, the campaign can definitely make use of your pledge -- so won't you reconsider?</div>
-    <div>You <a href="{{try_again_url}}">can finish the pledge transaction</a>.</div>
+    <div>You were about to pledge ${{ transaction.amount }} to <a href="{% url work work.id %}">{{ work.title }}</a> but hit the cancel link.
+    Naturally, we won't be charging you for this campaign without your permission.</div>
+    <div>However, the campaign can definitely make use of your pledge.  If you hit cancel by mistake, you can <a href="{{ try_again_url }}">finish the pledge transaction</a>.</div>
 
 {% else %}
     <div>We're sorry; we can't figure out which transaction you're talking about.  If you meant to cancel a pledge, please go to the book's page and hit the Modify link.</div>

--- a/frontend/templates/privacy.html
+++ b/frontend/templates/privacy.html
@@ -47,7 +47,7 @@ Date of last revision: December 13, 2011
 
 <h3>Payment</h3>
 
-<p>We do not collect your credit card information. All financial transactions are processed through Paypal; information is transmitted securely using SSL and the Paypal APIs. You provide your credit card number, address, and other transaction information directly to Paypal; unglue.it does not transmit or store this information. unglue.it does not share your account information with Paypal.</p>
+<p>We do not collect your credit card information. All financial transactions are processed through Stripe; information is transmitted securely using SSL and the Stripe APIs. You provide your credit card number, address, and other transaction information directly to Stripe; Unglue.it does not transmit or store this information. unglue.it does not share your account information with Stripe.</p>
 
 <h3>Changes to this Privacy Policy</h3>
 


### PR DESCRIPTION
This should remove all user-visible Paypal and Amazon refs except those in our Terms of Service, which might need lawyerish approval.
