### PR TITLE
created editions may have cover images but not google books ids

### DIFF
--- a/frontend/templates/work.html
+++ b/frontend/templates/work.html
@@ -119,7 +119,7 @@ $j(document).ready(function(){
                     </div>
                     {% else %}
                     <div id="book-detail-img">
-                        <img src="/static/images/generic_cover_larger.png" alt="{{ work.title }}" title="{{ work.title }}" width="131" height="192" />
+                        <img src="{% if work.cover_image_thumbnail %}{{ work.cover_image_thumbnail }}{% else %}/static/images/generic_cover_larger.png{% endif %}" alt="{{ work.title }}" title="{{ work.title }}" width="131" height="192" />
                     </div>
                     {% endif %}
                     <div class="book-detail-info">


### PR DESCRIPTION
work.html assumed that books without googlebooks ids couldn't have cover images, hence only showed default image

However, editions we create manually may have cover images and not googlebooks ids . Example: our campaign book Third Awakening (https://unglue.it/work/113782/ ), and possibly by analogy anything from Smashwords.

Let's show the image if we have it.
