### PR TITLE
[#37736995] the old error message for a CC error was potentially confusing

### DIFF
--- a/frontend/templates/pledge_card_error.html
+++ b/frontend/templates/pledge_card_error.html
@@ -15,9 +15,9 @@
 <div class="jsmodule rounded clearfix">
     <div class="jsmod-content">
 
-	<div><h2>Error: Card authorization for a pledge transaction</h2>
+	<div><h2>Error: Card authorization</h2>
 		<div>
-		<p>Unglue.it would like to process your pledge, but there's been some problem processing your credit card (<b>{{exception.message}}</b>). Please <a href="{{ request.get_full_path }}">try again</a>, or  contact <a href="mailto:support@gluejar.com?subject={{ request.get_full_path|urlencode }}">unglue.it support</a>.
+		<p>Unglue.it would like to accept your credit card, but we encountered the following problem: <b>{{exception.message}}</b>. Please <a href="{{ request.get_full_path }}">try again</a>, or  contact <a href="mailto:support@gluejar.com?subject={{ request.get_full_path|urlencode }}">unglue.it support</a>.
         </p>
         </div>
 	</div>


### PR DESCRIPTION
 I think this should be better -- see images in

https://www.evernote.com/shard/s1/sh/b59d4cfa-81a2-42bc-a315-24996fb01e83/2cfa234f2a15042ff0bb198514771dcb
