### PR TITLE
[#41908015] 'incorrect_number' and 'processing_error' error should also ...

### DIFF
--- a/payment/stripelib.py
+++ b/payment/stripelib.py
@@ -659,7 +659,7 @@ class Processor(baseprocessor.Processor):
 
                     # fire off the fact that transaction failed -- should actually do so only if not a transient error
                     # if card_declined or expired card, ask user to update account
-                    if e.code in ('card_declined', 'expired_card'):
+                    if e.code in ('card_declined', 'expired_card', 'incorrect_number', 'processing_error'):
                         transaction_failed.send(sender=self, transaction=transaction)
                     # otherwise, report exception to us
                     else:


### PR DESCRIPTION
...result in pledge_failed notice ->

catch incorrect_number (and processing_error for now) for sending the pledge_failed notice
