### PR TITLE
update social auth and django to fix broken twitter auth

### DIFF
--- a/requirements_versioned.pip
+++ b/requirements_versioned.pip
@@ -1,4 +1,4 @@
-Django==1.4.2
+Django==1.4.5
 Fabric==1.4.3
 MySQL-python==1.2.3
 Pillow==1.7.7
@@ -26,7 +26,7 @@ git+git://github.com/aladagemre/django-notification.git@2927346f4c513a217ac8ad07
 django-registration==0.8
 django-selectable==0.5.2
 django-smtp-ssl==1.0
-django-social-auth==0.7.5
+django-social-auth==0.7.20
 django-storages==1.1.6
 django-tastypie==0.9.11
 feedparser==5.1.2

--- a/settings/common.py
+++ b/settings/common.py
@@ -209,6 +209,12 @@ AUTHENTICATION_BACKENDS = (
 SOCIAL_AUTH_ENABLED_BACKENDS = ['google', 'facebook', 'twitter']
 SOCIAL_AUTH_ASSOCIATE_BY_MAIL = True
 SOCIAL_AUTH_NEW_USER_REDIRECT_URL = '/'
+# following is needed because of length limitations in a unique constrain for MySQL
+# see https://github.com/omab/django-social-auth/issues/539
+SOCIAL_AUTH_UID_LENGTH = 222
+SOCIAL_AUTH_NONCE_SERVER_URL_LENGTH = 200
+SOCIAL_AUTH_ASSOCIATION_SERVER_URL_LENGTH = 135
+SOCIAL_AUTH_ASSOCIATION_HANDLE_LENGTH = 125
 
 TWITTER_EXTRA_DATA = [('profile_image_url', 'profile_image_url')]
 


### PR DESCRIPTION
before this can be installed on an existing database, the following
south command must be applied:
django-admin.py convert_to_south social_auth
