### PR TITLE
I think I had a Y2.0144K problem

### DIFF
--- a/core/fixtures/basic_campaign_test.json
+++ b/core/fixtures/basic_campaign_test.json
@@ -511,7 +511,7 @@
       "name": "Pro Web 2.0 Mashups", 
       "edition": null, 
       "amazon_receiver": "", 
-      "deadline": "2013-04-10T23:59:00", 
+      "deadline": "2023-04-10T23:59:00", 
       "details": "<p>\r\n\tTEST EDITION/RIGHTS DETAILS</p>\r\n", 
       "left": "5000.00", 
       "target": "5000.00"
@@ -534,7 +534,7 @@
       "name": "Moby Dick", 
       "edition": null, 
       "amazon_receiver": "", 
-      "deadline": "2013-04-12T23:59:00", 
+      "deadline": "2023-04-12T23:59:00", 
       "details": "<p>\r\n\tThe book is already in the public domain, but let&#39;s do this again.</p>\r\n", 
       "left": "15000.00", 
       "target": "15000.00"


### PR DESCRIPTION
Our tests started to fail mysteriously on April 20, 2013 (http://jenkins.unglueit.com/job/regluit/1969/) for https://github.com/Gluejar/regluit/commit/d977fd633822251f46868a5d410b6d44551baa3d -- even tests were ok for previous week.

Problem arose on April 20 because I had hard coded a campaign completion date for a test campaign in https://github.com/Gluejar/regluit/commit/e34f2ce3a38da09f6592e39d34ee3fc78621ece8#L0L537 (core/fixtures/basic_campaign_test.json) Moby Dick campaign for 2013-04-12T23:59:00 -- the test assumed that a stripe charge would be recharged, which it would be for up to 7 (or 8? I can't remember) days after close of campaign.  

Solution for now:  move deadline to 2023-04-12.
