### PR TITLE
Tidy landing page

### DIFF
--- a/frontend/templates/home.html
+++ b/frontend/templates/home.html
@@ -64,7 +64,7 @@ function put_un_in_cookie2(){
                                 {% include "book_panel.html" %}
                             {% endwith %}{% endwith %}{% endwith %}
                         {% endfor %}
-                        <a class="more_featured_books" href="{% url campaign_list 'ending' %}"></a>
+                        <a class="more_featured_books" href="{% url campaign_list 'soon' %}"></a>
                     </div>
                 {% endif %}{% endif %}
                 <div class="spacer"></div>

--- a/frontend/views.py
+++ b/frontend/views.py
@@ -740,6 +740,8 @@ class CampaignListView(FilterableListView):
             return models.Campaign.objects.filter(status='ACTIVE').all() # STUB: will need to make db changes to make this work 
         elif (facet == 'ending'):
             return models.Campaign.objects.filter(status='ACTIVE').order_by('deadline')
+        elif (facet == 'soon'):
+            return models.Campaign.objects.filter(status='INITIALIZED').order_by('-work__num_wishes')
         else:
             return models.Campaign.objects.all()
 


### PR DESCRIPTION
Replaces "active campaigns" with "coming soon" on landing page when there are no active campaigns; skips entirely if there are neither active nor initialized campaigns.  "coming soon" links to new campaign-list page, sorted by wishes.
