### PR TITLE
Adding Google books api key to the search

### DIFF
--- a/core/search.py
+++ b/core/search.py
@@ -3,6 +3,8 @@ import json
 import requests
 import regluit.core.isbn
 
+from django.conf import settings
+
 def gluejar_search(q, user_ip='69.243.24.29', page=1):
     """normalizes results from the google books search suitable for gluejar
     """
@@ -56,6 +58,9 @@ def googlebooks_search(q, user_ip, page):
     headers = {'X-Forwarded-For': user_ip}
     start = (page - 1) * 10 
     params = {'q': q, 'startIndex': start, 'maxResults': 10}
+    if hasattr(settings, 'GOOGLE_BOOKS_API_KEY'):
+        params['key'] = settings.GOOGLE_BOOKS_API_KEY
+        
     r = requests.get('https://www.googleapis.com/books/v1/volumes', 
             params=params, headers=headers)
     return json.loads(r.content)


### PR DESCRIPTION
use GOOGLE_BOOKS_API_KEY if available.  (it might be better to use a try/except structure or just assume that the django settings exists -- but let me see whether this fixes the problem on unglue.it)
