### PR TITLE
[#54240150] Changed ISBN of the Chinese book in https://github.com/Gluej...

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -91,7 +91,9 @@ class BookLoaderTests(TestCase):
         edition.set_publisher(u'Penguin')
         self.assertEqual(edition.publisher, u'test publisher name') # Penguin has been aliased
         # locale in language
-        edition = bookloader.add_by_isbn('9787500676911')
+        # Obama Dreams from My Father, Chinese edition
+        # http://www.worldcat.org/title/oubama-de-meng-xiang-zhi-lu-yi-fu-zhi-ming/oclc/272997721&referer=brief_results
+        edition = bookloader.add_by_isbn('9789571349268')
         self.assertEqual(edition.work.language, 'zh')
 
     # @unittest.expectedFailure


### PR DESCRIPTION
...ar/regluit/blob/master/core/tests.py#L95 because old ISBN no longer in Google Book

Issue laid out in https://www.pivotaltracker.com/story/show/54240150
(core.BookLoaderTests.test_add_by_isbn broken because a Chinese edition of Wikinomics disappeared from Google Books)
