### PR TITLE
Notices, not Messages

### DIFF
--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -88,7 +88,7 @@
                         <ul id="user_menu">
                             <li><a href="{% url supporter user %}">My Books</a></li>
                             <li>
-                                <a href="/notification"><span>Messages</span>
+                                <a href="/notification"><span>Notices</span>
                                     {% if unseen_count %}
                                         <span id="i_haz_notifications" class="unseen_count">{{ unseen_count }}</span>
                                     {% else %}


### PR DESCRIPTION
A review of the entire site reveals that we use "Messages" in only one
place, the sitewide menu item leading to the notices page. Most of our
Notices are more acurately described as notices than as messages, so
will change the menu item.
