### PR TITLE
didn't have a template for a failed email-change

### DIFF
--- a/frontend/templates/email_change/email_verify.html
+++ b/frontend/templates/email_change/email_verify.html
@@ -10,7 +10,7 @@
     <h1>{% trans "Email confirmation failed" %}</h1>
 {% endblock %}
 
-{% block content %}
+{% block doccontent %}
     <div id="content-main">
         <p>{% trans "This confirmation code has either expired or is invalid." %}</p>
         <p>{% trans "The requested email address change has failed." %}</p>


### PR DESCRIPTION
If your username has a '@' in it, and you tried to change your email to a bad address, the confirm email response would throw a display error. To test this, it's sufficient to try test a email verify address, such as http://localhost:8000/accounts/email/verify/x/ which will throw an error in the current code
