### PR TITLE
drop emit_notifications from celery right now since we're using crontab ...

### DIFF
--- a/settings/just.py
+++ b/settings/just.py
@@ -138,7 +138,8 @@ IS_PREVIEW = False
 #CELERYBEAT_SCHEDULE['send_test_email'] = SEND_TEST_EMAIL_JOB
 CELERYBEAT_SCHEDULE['report_new_ebooks'] = EBOOK_NOTIFICATIONS_JOB
 
-CELERYBEAT_SCHEDULE['emit_notifications'] = EMIT_NOTIFICATIONS_JOB
+# doing emit_notifications in crontab right now
+#CELERYBEAT_SCHEDULE['emit_notifications'] = EMIT_NOTIFICATIONS_JOB
 
 CELERYBEAT_SCHEDULE['update_account_statuses'] = UPDATE_ACCOUNT_STATUSES
 CELERYBEAT_SCHEDULE['notify_expiring_accounts'] = NOTIFY_EXPIRING_ACCOUNTS


### PR DESCRIPTION
...for now
