### PR TITLE
Add missing {{ acq.work.title }} to library_reserve/full.txt

### DIFF
--- a/frontend/templates/notification/library_reserve/full.txt
+++ b/frontend/templates/notification/library_reserve/full.txt
@@ -1,4 +1,4 @@
- is reserved for you from {{ acq.lib_acq.user.username }} until {{ acq.expires }}.  You can borrow the ebook by downloading it from the book's download page:
+{{ acq.work.title }} is reserved for you from {{ acq.lib_acq.user.username }} until {{ acq.expires }}.  You can borrow the ebook by downloading it from the book's download page:
 https://{{ current_site.domain }}{% url download acq.work.id %}
 
 If you don't download the book before {{ acq.expires }}, other members of {{ acq.lib_acq.user.username }} will be able to use it instead.


### PR DESCRIPTION
Book title missing in email -- e.g., 

> is reserved for you from TestLibrary until Nov. 27, 2013, 2:17 p.m..  You can borrow the ebook by downloading it from the book's download page: https://just.unglue.it/work/846/download/
