### PR TITLE
authors should always return a query set

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -1079,7 +1079,7 @@ class Work(models.Model):
         for edition in self.editions.all():
             if edition.authors.all().count()>0:
                 return edition.authors.all()
-        return []
+        return Author.objects.none()
         
     def author(self):
         # assumes that they come out in the same order they go in!


### PR DESCRIPTION
Fixes this:
Traceback (most recent call last):

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 111, in get_response
   response = callback(request, _callback_args, *_callback_kwargs)

 File "/opt/regluit/frontend/views.py", line 2392, in work_openlibrary
   q = urlencode({'q': work.title + " " + work.author()})

 File "/opt/regluit/core/models.py", line 1086, in author
   if self.authors().count()>0:

TypeError: count() takes exactly one argument (0 given)

<WSGIRequest
path:/work/121075/openlibrary/,
