### PR TITLE
various improvements in documentation

### DIFF
--- a/frontend/templates/ebookfiles.html
+++ b/frontend/templates/ebookfiles.html
@@ -1,0 +1,21 @@
+<ul class="terms">
+<li><i>For Thanks-For-Ungluing Campaigns</i>, the rightsholder is responsible for providing valid, high-quality EPUB, MOBI, and PDF files.</li>
+<li><i>For Buy-To-Unglue Campaigns</i> and <i>Pledge Campaigns</i> ebook files should use the EPUB standard format format according to best practice at time of submission. At minimum, the files should pass the <a href=https://code.google.com/p/epubcheck/">epubcheck</a> tool. Exceptions will be made for content requiring more page layout than available in prevailing EPUB implementations; in those cases, the files will usually be PDF.</li>
+<li>Files shall be compliant where ever reasonable with the QED inspection checklist specified at <a href="http://qed.digitalbookworld.com/why-qed/criteria">http://qed.digitalbookworld.com/why-qed/criteria</a> </li>
+<li>The file should have no more than 0.2 typographical or scanning errors per page of English text.</li>
+<li>The file shall contain front matter which includes the following:
+<ul class="terms">
+<li>a list of ISBNs of other editions of the work</li>
+<li> <i>For Pledge Campaigns only</i><ol>
+<li>the Creative Commons license selected for the campaign, formatted in accordance with best practices at <a href="http://wiki.creativecommons.org/Marking/Creators">http://wiki.creativecommons.org/Marking/Creators</a>, and a statement that for the purposes of the license, "Non-Commercial" use shall include, but not be limited to, the distribution of the Work by a commercial entity without charge.</li>
+<li>an acknowledgement of Ungluers of the work, formatted in accordance with the premium descriptions on the Campaign page.</li>
+<li>The Unglue.it logo</li>
+<li>the text “CC edition release enabled by Unglue.it users” (including the hyperlink to the site)</li>
+<li>The Rights Holder must offer the schedule of Standard Premiums as described at at ( <a href="https://unglue.it/rightsholders/">https://unglue.it/rightsholders/</a>) in effect at the time of  launching a Pledge Campaign.</li>
+</ol>
+</li>
+<li><i>For Buy-To-Unglue Campaigns</i>, the Unglue.it platform will embed a personalized licensed statement into front matter for each delivered file</li>
+</ul>
+<li>The cover graphic shall match any description given in the Campaign.</li>
+<li>Any graphics which must be excluded from the released ebook shall be specified in the description given in the campaign.</li>
+</ul>

--- a/frontend/templates/faq.html
+++ b/frontend/templates/faq.html
@@ -385,7 +385,7 @@ Unglue.it signs agreements assuring the copyright status of every work we unglue
 <dl>
 <dt>What do I need to do to become an authorized Rights Holder on Unglue.it?</dt>
 
-<dd>Contact our Rights Holder Relations team, <a href="mailto:rights@gluejar.com">rights@gluejar.com</a>, to discuss signing our Platform Services Agreement (PSA), setting a revenue goal, and running a campaign on Unglue.it to release your book under a <a href="http://creativecommons.org">Creative Commons</a> license.<br /><br />
+<dd>Contact our Rights Holder Relations team, <a href="mailto:rights@gluejar.com">rights@gluejar.com</a>, to discuss signing our <a href="https://www.docracy.com/1mud3ve9w8/unglue-it-non-exclusive-platform-services-agreement">Platform Services Agreement (PSA)</a>, setting a revenue goal, and running a campaign on Unglue.it to release your book under a <a href="http://creativecommons.org">Creative Commons</a> license, or to raise money for a book you've already released under such a license.<br /><br />
 The more Unglue.it knows about you and your books, the faster your campaign can be up and running.<br /><br />
 For example, it would help to have you tell us the following in your initial query:<br /><br />
 <em>About your books:</em>
@@ -397,7 +397,7 @@ For example, it would help to have you tell us the following in your initial que
 <li>Have you self-published this title or other works?</li>
 <li>Have you already applied a Creative Commons license to this work?</li>
 </ul>
-<em>Note:  If you have an EPUB file ready to sell, you should use a "Buy to Unglue" campaign. If there is no ebook yet, you'll want to offer a "Pledge" campaign.</em><br /><br />
+<em>Note:  If you have an EPUB file ready to sell, you should use a "Buy to Unglue" campaign. If there is no ebook yet, you'll want to offer a "Pledge" campaign.</em> And if you've already put a Creative Common License on the Book, you can use a "Thanks for Ungluing" Campaign.<br /><br />
 <em>About the ebook rights:</em>
 <ul class="bullets">
 <li>If you are the copyright holder, have ebook rights reverted to you or have you requested reversion from the original publisher? </li>
@@ -412,6 +412,13 @@ For example, it would help to have you tell us the following in your initial que
 <li>How have you worked with libraries to promote your books in the past?</li>
 <li>Where do you think your key supporters will come from? -- a community of fans you're already in touch with, fans who read your genre, readers who have yet to discover your work, scholars or students, readers who support the open access movement or free culture?</li>
 </ul>
+</dd>
+
+<dt>I haven't signed an agreement, but my books are listed on Unglue.it. What's going on?</dt>
+<dd>If your book is listed on Unglue.it, it's because an unglue.it user has indicated some interested in the book. Perhaps your book has been added to a user's favorites list. Users can also use the site to post links to Creative Commons licensed or public domain books. Unglue.it works with non-profit sites such as Internet Archive to improve their coverage and preservation of Creative Commons licensed books.
+</dd>
+<dt>I didn't give you permission to offer my CC-licensed book for download. Why is it there?</dt>
+<dd>When we don't have an agreement with a rights-holder, our download links lead to only reputable sites such as Internet Archive, Project Gutenberg, or Google Books. We are able to provide those links based on the fair use provisions of copyright. We strive to keep our information accurate, so the license we report is inaccurate, please <a href="mailto:rights@gluejar.com?subject=corrections">let us know</a> immediately. If for some reason you don't want us to provide download links, let us know using the "feedback" tab next to your book's page and we'll make a notation to that effect in our metadata. We may require evidence that you are authorized to act for the rights holders of your book.
 </dd>
 
 <dt>Do I need to know the exact titles I might want to unglue before I sign the Platform Services Agreement?</dt>
@@ -553,6 +560,13 @@ Need more ideas?  We're happy to work with rights holders personally to craft a 
 <dt>Will Unglue.it raise money to help pay for conversion costs?</dt>
 
 <dd>A Pledge campaign target should include conversion costs. For a Buy-to-Unglue and Thanks-for-Ungluing campaigns, you'll need to have pre-existing epub files.</dd>
+
+<dt>What are the requirements for my ebook files?</dt>
+
+<dd>
+{% include 'ebookfiles.html' %}
+</dd>
+
 </dl>
 {% endif %}
 {% if sublocation == 'funding' or sublocation == 'all' %}

--- a/frontend/templates/rh_tools.html
+++ b/frontend/templates/rh_tools.html
@@ -23,11 +23,11 @@ Any questions not covered here?  Please email us at <a href="mailto:rights@gluej
 <p>
     <a href="/static/images/How_to_claim_your_work.mp4">How to claim your work</a> (screencast)
 </p>
-
+{% comment %}
 <p>
     <a href="/static/images/How_to_set_up_your_campaign.mp4">How to set up your campaign</a> (screencast)
 </p>
-
+{% endcomment %}
 <p>
     <a href="/static/images/How_to_embed_a_widget.mp4">How to embed a widget for your book</a> in your blog, web site, etc. (screencast)
 </p>

--- a/frontend/templates/terms.html
+++ b/frontend/templates/terms.html
@@ -154,27 +154,7 @@ The Company's mission is to make copyrighted literary works freely and readily a
 <p>The Rights Holder shall not, whether as a Premium or otherwise, use the Service to offer any financial incentive to potential Ungluers.  The prohibition against financial incentives expressly includes, but is not limited to, a share of profits or ownership interest in any entity, interest payable on any Contributions, or any Premium that would require registration under the securities laws of any country or state, including but not limited to the state or federal securities laws and regulations of the United States.</p>
 
 <p>The Standard Ebook File shall meet the following  set of criteria:</p>
-<ul class="terms">
-<li>Unless otherwise permitted in writing by Unglue.it, the file shall use the EPUB standard format format according to best practice at time of submission. Exceptions will be made for content requiring more page layout than available in prevailing EPUB implementations.</li>
-<li>The file shall be compliant where ever reasonable with the QED inspection checklist specified at <a href="http://qed.digitalbookworld.com/why-qed/criteria">http://qed.digitalbookworld.com/why-qed/criteria</a> </li>
-<li>The file should have no more than 0.2 typographical or scanning errors per page of English text.</li>
-<li>The file shall contain front matter which includes the following:
-<ul class="terms">
-<li>a list of ISBNs of other editions of the work</li>
-<li> <i>For Pledge Campaigns only</i><ol>
-<li>the Creative Commons license selected for the campaign, formatted in accordance with best practices at <a href="http://wiki.creativecommons.org/Marking/Creators">http://wiki.creativecommons.org/Marking/Creators</a>, and a statement that for the purposes of the license, "Non-Commercial" use shall include, but not be limited to, the distribution of the Work by a commercial entity without charge.</li>
-<li>an acknowledgement of Ungluers of the work, formatted in accordance with the premium descriptions on the Campaign page.</li>
-<li>The Unglue.it logo</li>
-<li>the text “CC edition release enabled by Unglue.it users” (including the hyperlink to the site)</li>
-<li>The Rights Holder must offer the schedule of Standard Premiums as described at at ( <a href="https://unglue.it/rightsholders/">https://unglue.it/rightsholders/</a>) in effect at the time of  launching a Pledge Campaign.</li>
-</ol>
-</li>
-<li><i>For Buy-To-Unglue Campaigns</i>, the Unglue.it platform will embed a personalized licensed statement into front matter for each delivered file</li>
-</ul>
-<li>The cover graphic shall match any description given in the Campaign.</li>
-<li>Any graphics which must be excluded from the released ebook shall be specified in the description given in the campaign.
-</ul>
-
+{% include 'ebookfiles.html' %}
 <p>To provide confirmation of Fulfillment and become eligible to receive Contributions made  in a successful Pledge Campaign, the Rights Holder shall either make available to the Company a Standard Ebook File for the work, or the Rights Holder shall designate a third party vendor from a list of vendors approved by the Company (the “Designated Vendor”) to create the converted eBook at a rate that has been established between the Designated Vendor and the Rights Holder (the “Conversion Cost.”)  The Rights Holder shall provide the Company with written notice of the name and contact information for the Designated Vendor, the Conversion Cost, and any supporting documentation or other verification as may be reasonably requested by the Company.</p>
 
 <p>In the event that the Company releases Ungluer information to the Rights Holder, or invites Ungluers to share such information with the Rights Holder, Rights Holders agree to treat such information in a manner consistent with the Company’s <a href="https://unglue.it/privacy/">Privacy Policy</a>.</p>

--- a/frontend/templates/work.html
+++ b/frontend/templates/work.html
@@ -45,7 +45,7 @@
 {% else %}
     {% if not work.user_with_rights %}
         {% if request.user.rights_holder.all %}
-            <div class="launch_top pale">Hi, {{ request.user.username }}. Since you're an authorized Unglue.it rights holder, if you own the worldwide electronic rights to this work, you may claim it through the More... tab. Need help?  There's a screencast of the process at the <a href="{% url rightsholders %}">rights holder tools page</a>.</div>            
+            <div class="launch_top pale">Hi, {{ request.user.username }}. Since you're an authorized Unglue.it rights holder, if you own the worldwide electronic rights to this work, you may claim it through the More... tab. Need help?  Check out the <a href="{% url rightsholders %}">rights holder tools page</a>.</div>            
         {% endif %}
     {% else %}
         {% if request.user == work.user_with_rights %}


### PR DESCRIPTION
1. rh's keep asking for file guidelines- I hunt it down in terms of use.
2. removed reference to screencast on starting a campaign. Andromeda begged off on revision because Verity was in hospital. (she's fine now!)
3. explanation of what we're doing when there's no agreement with rightsholders (download buttons are links)

this PR is documentation only, please expedite.
