### PR TITLE
Need to point to github for pyzotero

### DIFF
--- a/requirements_versioned.pip
+++ b/requirements_versioned.pip
@@ -3,7 +3,7 @@ Fabric==1.4.3
 MySQL-python==1.2.3
 Pillow==1.7.7
 PyPDF2==1.20
-Pyzotero==0.9.51
+git+git://github.com/urschrei/pyzotero.git@v0.9.51
 South==0.7.6
 WebOb==1.2.3
 WebTest==1.4.0


### PR DESCRIPTION
In the process of coming back to work on the `sysadmin` branch (and specifically on a script to build unglue.it from scratch), I see that the pyzotero library needs to be referenced differently in requirements_versioned.pip
