### PR TITLE
handle exception when no edition

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -1159,6 +1159,7 @@ class Work(models.Model):
             self.save()
             return self.selected_edition 
         except IndexError:
+            #should only happen if there are no editions for the work
             return None
         
     def last_campaign_status(self):
@@ -1272,6 +1273,8 @@ class Work(models.Model):
         self.save()
 
     def first_oclc(self):
+        if self.preferred_edition == None:
+            return ''
         preferred_id=self.preferred_edition.oclc
         if preferred_id:
             return preferred_id
@@ -1281,6 +1284,8 @@ class Work(models.Model):
             return ''
 
     def first_isbn_13(self):
+        if self.preferred_edition == None:
+            return ''
         preferred_id=self.preferred_edition.isbn_13
         if preferred_id:
             return preferred_id


### PR DESCRIPTION
Occurred for 100 years of solitude probably during regrouping.

A rare bug.

Traceback (most recent call last):

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 111, in get_response
   response = callback(request, _callback_args, *_callback_kwargs)

 File "/opt/regluit/frontend/views.py", line 425, in work
   'formset': formset,

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/shortcuts/**init**.py", line 44, in render
   return HttpResponse(loader.render_to_string(_args, *_kwargs),

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/loader.py", line 176, in render_to_string
   return t.render(context_instance)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 140, in render
   return self._render(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 134, in _render
   return self.nodelist.render(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 823, in render
   bit = self.render_node(node, context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 837, in render_node
   return node.render(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/loader_tags.py", line 123, in render
   return compiled_parent._render(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 134, in _render
   return self.nodelist.render(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 823, in render
   bit = self.render_node(node, context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 837, in render_node
   return node.render(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/loader_tags.py", line 62, in render
   result = block.nodelist.render(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 823, in render
   bit = self.render_node(node, context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 837, in render_node
   return node.render(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/defaulttags.py", line 476, in render
   output = self.nodelist.render(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 823, in render
   bit = self.render_node(node, context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 837, in render_node
   return node.render(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/defaulttags.py", line 476, in render
   output = self.nodelist.render(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 823, in render
   bit = self.render_node(node, context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 837, in render_node
   return node.render(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/defaulttags.py", line 274, in render
   match = condition.eval(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/defaulttags.py", line 823, in eval
   return self.value.resolve(context, ignore_failures=True)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 571, in resolve
   obj = self.var.resolve(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 721, in resolve
   value = self._resolve_lookup(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 772, in _resolve_lookup
   current = current()

 File "/opt/regluit/core/models.py", line 1265, in first_oclc
   preferred_id=self.preferred_edition.oclc

AttributeError: 'NoneType' object has no attribute 'oclc'

<WSGIRequest
path:/work/136472/,
GET:<QueryDict: {}>,
POST:<QueryDict: {}>,
COOKIES:{'__utma': '192122478.1101540512.1398289208.1398289208.1398289208.1',
'__utmb': '192122478.2.10.1398289208',
'__utmc': '192122478',
'__utmz': '192122478.1398289208.1.1.utmcsr=(direct)|utmccn=(direct)|utmcmd=(none)',
'sessionid': 'c303945100387301ad00fd9bf3cb71b5'},
META:{'CSRF_COOKIE': 'uVgAwbqztlnrPcRKtGmaF2LQqea6hiWa',
'DOCUMENT_ROOT': '/etc/apache2/htdocs',
'GATEWAY_INTERFACE': 'CGI/1.1',
'HTTPS': '1',
'HTTP_ACCEPT': 'text/html,application/xhtml+xml,application/xml;q=0.9,_/_;q=0.8',
'HTTP_ACCEPT_ENCODING': 'gzip, deflate',
'HTTP_ACCEPT_LANGUAGE': 'es-es',
'HTTP_CONNECTION': 'keep-alive',
'HTTP_COOKIE': '__utma=192122478.1101540512.1398289208.1398289208.1398289208.1; __utmb=192122478.2.10.1398289208; __utmc=192122478; __utmz=192122478.1398289208.1.1.utmcsr=(direct)|utmccn=(direct)|utmcmd=(none); sessionid=c303945100387301ad00fd9bf3cb71b5',
'HTTP_HOST': 'unglue.it',
'HTTP_REFERER': 'https://unglue.it/search/?q=Soledad',
'HTTP_USER_AGENT': 'Mozilla/5.0 (iPad; CPU OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Mobile/10B329',
'PATH_INFO': u'/work/136472/',
'PATH_TRANSLATED': '/opt/regluit/deploy/regluit.wsgi/work/136472/',
'QUERY_STRING': '',
'REMOTE_ADDR': '83.36.33.116',
'REMOTE_PORT': '50009',
'REQUEST_METHOD': 'GET',
'REQUEST_URI': '/work/136472/',
'SCRIPT_FILENAME': '/opt/regluit/deploy/regluit.wsgi',
'SCRIPT_NAME': u'',
'SCRIPT_URI': 'https://unglue.it/work/136472/',
'SCRIPT_URL': '/work/136472/',
'SERVER_ADDR': '10.245.182.34',
'SERVER_ADMIN': '[no address given]',
'SERVER_NAME': 'unglue.it',
'SERVER_PORT': '443',
'SERVER_PROTOCOL': 'HTTP/1.1',
'SERVER_SIGNATURE': '<address>Apache/2.2.20 (Ubuntu) Server at unglue.it Port 443</address>\n',
'SERVER_SOFTWARE': 'Apache/2.2.20 (Ubuntu)',
'SSL_TLS_SNI': 'unglue.it',
'mod_wsgi.application_group': 'ip-10-245-182-34.ec2.internal|',
'mod_wsgi.callable_object': 'application',
'mod_wsgi.handler_script': '',
'mod_wsgi.input_chunked': '0',
'mod_wsgi.listener_host': '',
'mod_wsgi.listener_port': '443',
'mod_wsgi.process_group': '',
'mod_wsgi.request_handler': 'wsgi-script',
'mod_wsgi.script_reloading': '1',
'mod_wsgi.version': (3, 3),
'wsgi.errors': <mod_wsgi.Log object at 0x7f61831d0cf0>,
'wsgi.file_wrapper': <built-in method file_wrapper of mod_wsgi.Adapter object at 0x7f618335c300>,
'wsgi.input': <mod_wsgi.Input object at 0x7f61831d0770>,
'wsgi.multiprocess': True,
'wsgi.multithread': True,
'wsgi.run_once': False,
'wsgi.url_scheme': 'https',
'wsgi.version': (1, 1)}>
