### PR TITLE
one more thing - indicate that download page is missing ebook links

### DIFF
--- a/frontend/templates/download.html
+++ b/frontend/templates/download.html
@@ -126,6 +126,9 @@ $j(document).ready(function() {
         </div>
     {% endif %}
     <div class="ebook_download_container">
+    {% if testmode %}
+        <i>Download links for uploaded files will appear here when campaign is launched.</i>
+    {% endif %}
     {% if unglued_ebooks or other_ebooks or acq %}
         {% if unglued_ebooks %}
             <h3>Download the unglued edition</h3>

--- a/frontend/views.py
+++ b/frontend/views.py
@@ -2746,6 +2746,7 @@ class DownloadView(PurchaseView):
             'user_license': self.user_license,
             'lib_thanked': self.lib_thanked,
             'amount': self.request.session.pop('amount') if self.request.session.has_key('amount') else None,
+            'testmode': self.request.REQUEST.has_key('testmode'),
         })
         return context
 


### PR DESCRIPTION
should have checked that OBP list of problems was all addressed:

I hope you're well. I've just been setting up our campaigns for The Digital Public Domain and The Classic Short Story on the unglue website. I've filled in all the necessary fields and created new editions for our PDF, epub and mobi versions, all of which I've uploaded. One difficulty I encountered was that I wasn't able to set any of these newly uploaded editions as the 'preferred edition', and none of them appeared on the preview pages for the campaigns - is this something you'll be able to fix at your end, or is there something else I need to do? 
