### PR TITLE
rights holder can create new work

### DIFF
--- a/frontend/templates/new_edition.html
+++ b/frontend/templates/new_edition.html
@@ -17,7 +17,9 @@
     <h2>Create New Edition</h2>
     {% endif %}
 {% else %}
+    {% if edition.pk %}
     <h2>Add Ebook Links for <a href="{% url work edition.work.id %}">{{ edition.work }}</a></h2>
+    {% endif %}
 {% endif %}
 
 {% if admin %}

--- a/frontend/templates/rh_tools.html
+++ b/frontend/templates/rh_tools.html
@@ -221,6 +221,7 @@ Any questions not covered here?  Please email us at <a href="mailto:rights@gluej
 	</ul></li>
 	<li>...or send us metadata for books you have rights to.
 	<ul>
+	    <li>Use <a href="{% url new_edition '' '' %}">this form</a> to enter the metadata.</li>
 	    <li>Your ebooks must have ISBNs assigned.</li>
 	    <li>Your metadata should have title, authors, language, description.</li>
 	    <li><a href="mailto:support@gluejar.com?subject=loading%20metadata">Contact us</a> to load ONIX or CSV files for you.</li>

--- a/frontend/views.py
+++ b/frontend/views.py
@@ -498,6 +498,8 @@ def new_edition(request, work_id, edition_id, by=None):
     elif work and work.last_campaign():
         if request.user in work.last_campaign().managers.all():
             admin = True
+    elif work==None and request.user.rights_holder.count():
+        admin = True
     if edition_id:
         try:
             edition = models.Edition.objects.get(id = edition_id)


### PR DESCRIPTION
john sundman noticed that there was no way for a a rh to enter a totally new book.
I found that new_edition failed for non- admin users
I added admin status for rights holders when there's no work specified, and link in rh_tools
