### PR TITLE
keep the book panels where they belong

### DIFF
--- a/frontend/templates/work_list.html
+++ b/frontend/templates/work_list.html
@@ -88,7 +88,7 @@
                         {% lazy_paginate 20 works_unglued using "works_unglued" %}
                         {% for work in works_unglued %}
                         <div class="{% cycle 'row1' 'row2' %}">
-                        {% with work.googlebooks_id as googlebooks_id %}					
+                        {% with googlebooks_id=work.googlebooks_id tab_override='tabs-1' %}					
                         {% include "book_panel.html" %}
                         {% endwith %}
                         </div>
@@ -102,7 +102,7 @@
                         {% lazy_paginate 20 works_active using "works_active" %}
                         {% for work in works_active %}
                         <div class="{% cycle 'row1' 'row2' %}">
-                        {% with work.googlebooks_id as googlebooks_id %}					
+                        {% with googlebooks_id=work.googlebooks_id  tab_override='tabs-2' %}					
                         {% include "book_panel.html" %}
                         {% endwith %}
                         </div>
@@ -117,7 +117,7 @@
                         {% lazy_paginate 20 works_wished using "works_wished" %}
                         {% for work in works_wished %}
                         <div class="{% cycle 'row1' 'row2' %}">
-                        {% with work.googlebooks_id as googlebooks_id %}					
+                        {% with googlebooks_id=work.googlebooks_id  tab_override='tabs-3' %}					
                         {% include "book_panel.html" %}
                         {% endwith %}
                         </div>


### PR DESCRIPTION
This should be the last fix for the evening.

We had an odd design pattern where the book panels wanted to make their own decision about which tab they should be in, and separately, there was a list. probably should remove the dependance entirely, but this fixes the instant problem of books trying to escape their tabs displayed on https://unglue.it/pid/all/4639
