### PR TITLE
let ebook go to default

### DIFF
--- a/frontend/forms.py
+++ b/frontend/forms.py
@@ -199,7 +199,7 @@ class EbookFileForm(forms.ModelForm):
 class EbookForm(forms.ModelForm):
     class Meta:
         model = Ebook
-        exclude =( 'created','download_count',)
+        exclude =( 'created', 'download_count', 'active')
         widgets = { 
                 'edition': forms.HiddenInput, 
                 'user': forms.HiddenInput, 


### PR DESCRIPTION
When you submit an ebook link, the active bit was inadvertently set to false. 
