### PR TITLE
Turning off SSL v2 and SSL v3 from Apache to patch against POODLE vulnerabillity

### DIFF
--- a/deploy/just.conf
+++ b/deploy/just.conf
@@ -33,6 +33,7 @@ Alias /static /var/www/static
 
 SSLEngine on
 ServerName just.unglue.it:443
+SSLProtocol All -SSLv2 -SSLv3
 SSLCertificateFile    /etc/ssl/certs/server.crt
 SSLCertificateKeyFile /etc/ssl/private/server.key
 SSLCertificateChainFile /etc/ssl/certs/STAR_unglue_it.ca-bundle

--- a/deploy/please.conf
+++ b/deploy/please.conf
@@ -29,6 +29,7 @@ Alias /static /var/www/static
 <VirtualHost _default_:443>
 
 SSLEngine on
+SSLProtocol All -SSLv2 -SSLv3
 SSLCertificateFile    /etc/ssl/certs/server.crt
 SSLCertificateKeyFile /etc/ssl/private/server.key
 #SSLCertificateChainFile /etc/ssl/certs/gd_bundle.crt

--- a/deploy/prod.conf
+++ b/deploy/prod.conf
@@ -40,6 +40,7 @@ CustomLog ${APACHE_LOG_DIR}/unglue.it-access.log combined
 
 ServerName unglue.it:443
 SSLEngine on
+SSLProtocol All -SSLv2 -SSLv3
 SSLCertificateFile    /etc/ssl/certs/server.crt
 SSLCertificateKeyFile /etc/ssl/private/server.key
 SSLCertificateChainFile /etc/ssl/certs/STAR_unglue_it.ca-bundle


### PR DESCRIPTION
I am turning off SSL v2 and v3 from Apache: http://askubuntu.com/questions/537196/how-do-i-patch-workaround-sslv3-poodle-vulnerability-cve-2014-3566
