### PR TITLE
a proposed fix for when edition.publisher_name is None

### DIFF
--- a/core/marc.py
+++ b/core/marc.py
@@ -190,7 +190,7 @@ def makemarc(marcfile,  edition):
             tag='260',
             indicators = [' ', ' '],
             subfields = [
-                'b', edition.publisher_name.name,
+                'b', edition.publisher_name.name if edition.publisher_name is not None else "",
                 'c', unicode(edition.publication_date),
             ]
         )


### PR DESCRIPTION
Eric:  is a good fix...or should the 'b' field not exist in such a case?
