### PR TITLE
dash in hostname is not an edge case [fix #82585632]

### DIFF
--- a/frontend/forms.py
+++ b/frontend/forms.py
@@ -132,7 +132,7 @@ class EditionForm(forms.ModelForm):
     http = forms.RegexField(
         label=_("HTTP URL"),
         # https://mathiasbynens.be/demo/url-regex
-        regex=re.compile(r"(https?|ftp)://(-\.)?([^\s/?\.#-]+\.?)+(/[^\s]*)?$",
+        regex=re.compile(r"(https?|ftp)://(-\.)?([^\s/?\.#]+\.?)+(/[^\s]*)?$",
                          flags=re.IGNORECASE|re.S ), 
         required = False,
         help_text = _("no spaces of funny stuff."),


### PR DESCRIPTION
turns out that the one thing the regex we picked gives a false negative for is not an insignificant edgecase
