### PR TITLE
fix bugs in editions management auth

### DIFF
--- a/frontend/templates/split.html
+++ b/frontend/templates/split.html
@@ -1,14 +1,20 @@
+{% if user.is_staff or user in work.last_campaign.managers.all  %}
 <form method="POST" action="#">
     {% csrf_token %}
     {{ formset.management_form }}
     {% for form in formset %}
-        {% if request.user.is_staff %}
-            <div style="float:right;text-align:right">{{ form.id }}Split: {{form.DELETE.0}}<br /><br />
-            Select: <input type="radio" value="{{ form.instance.id }}" name="select_edition" /></div>
-        {% endif %}
+        <div style="float:right;text-align:right">{{ form.id }}Split: {{form.DELETE.0}}<br /><br />
+        Select: <input type="radio" value="{{ form.instance.id }}" name="select_edition" /></div>
         {% with form.instance as edition %}
             {% include 'edition_display.html' %}
         {% endwith %}
     {% endfor %}
-    {% if request.user.is_staff %}<input type="submit" value="Split/Select Editions" name="submit" />{% endif %}
+    <input type="submit" value="Split/Select Editions" name="submit" />
 </form>
+{% else %}
+    {% for form in formset %}
+        {% with form.instance as edition %}
+            {% include 'edition_display.html' %}
+        {% endwith %}
+    {% endfor %}
+{% endif %}

--- a/frontend/views.py
+++ b/frontend/views.py
@@ -332,7 +332,7 @@ def work(request, work_id, action='display'):
         return acks( request, work)
     elif action == "editions":
         EditionFormSet = inlineformset_factory(models.Work, models.Edition, fields=(), extra=0 )    
-        if request.method == "POST" and (request.user.is_staff or user in work.last_campaign().managers.all()):
+        if request.method == "POST" and (request.user.is_staff or (work.last_campaign() and request.user in work.last_campaign().managers.all())):
             formset = EditionFormSet(data=request.POST, instance=work)
             if formset.is_valid():
                 for form in formset.deleted_forms:


### PR DESCRIPTION
fix bug exposed by a crawler. email report Nov 27 1:05PM:
[Django] ERROR (EXTERNAL IP): Internal Server Error: /work/99757/editions/

To reproduce the bug, got to /work/99757/editions/ as staff. In a separate window, log out, then come back and submit the form.

Changed template so empty form is no longer exposed.
Also enabled form for non-staff campaign managers; template was not consistent with view
