### PR TITLE
upgrade from Django 1.4.5 to 1.4.19

### DIFF
--- a/requirements_versioned.pip
+++ b/requirements_versioned.pip
@@ -1,4 +1,4 @@
-Django==1.4.5
+Django==1.4.19
 Fabric==1.4.3
 MySQL-python==1.2.3
 Pillow==2.5.3


### PR DESCRIPTION
stepping stone to upgrading to newest versions of Django:  first upgrade to latest branch of 1.4.x

(I should have been upgrading along the 1.4.x branch all along since these upgrades are supposed to bug/security fixes that are supposedly backwards-compatible.)
