### PR TITLE
add inactive download counts in rh tools [fix #88928040]

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -1247,7 +1247,10 @@ class Work(models.Model):
     def percent_of_goal(self):
         campaign = self.last_campaign()
         return 0 if campaign is None else campaign.percent_of_goal()
-
+    
+    def ebooks_all(self):
+        return self.ebooks(all=True)
+        
     def ebooks(self, all=False):
         if all:
             return Ebook.objects.filter(edition__work=self).order_by('-created')

--- a/frontend/templates/rh_tools.html
+++ b/frontend/templates/rh_tools.html
@@ -179,10 +179,11 @@ If you're an author, publisher, or other rights holder, you can participate more
 			{% endif %}
 			{% if claim.work.first_ebook %}
 				<h4> Ebooks for this work </h4>
+				<p>{{ claim.work.download_count }} total downloads</p>
 				<div class="work_campaigns">
 				<ul>
-				{% for ebook in claim.work.ebooks %}
-					<li> edition #{{ebook.edition.id}} {{ ebook.format }}
+				{% for ebook in claim.work.ebooks_all %}
+					<li> edition #{{ebook.edition.id}} {{ ebook.format }} {% if not ebook.active %}(inactive){% endif %}
 					{{ ebook.download_count }} downloads
 					</li>
 				{% endfor %}


### PR DESCRIPTION
Hi Eric,

I'm very sorry to trouble you.

I've just noticed that on our campaign page (in the "more" tab -
https://unglue.it/work/136328/#) the sum of the number of downloads for
each of the three formats (274) and the total number of downloads (667)
don't add up.

I don't seem to find the way to change this on our side, using the right
manager tools.

Is it something that can be fixed at your end?

Many thanks and best wishes,
Bianca

What's going on here is that there are two obsolete ebook files- see https://unglue.it/rightsholders/campaign/132/

and downloads for these are not broken out in the public display.

It will be easiest for us to add these on the campaign page- does that work for you?

Eric

Yes, please, go ahead!

Many thanks and best wishes,
Bianca
