### PR TITLE
flag kindle email addressed that don't contain "kindle" in them

### DIFF
--- a/frontend/templates/kindle_change_successful.html
+++ b/frontend/templates/kindle_change_successful.html
@@ -23,7 +23,9 @@
 {% block ce_content %}
     <h2>Kindle email change successful</h2>
     <div id="content-main">
-        <p>Hooray!  We can now send most unglued ebooks to you at {{ request.user.profile.kindle_email }}. Some ebooks are too big for us to send, though.</p>
+    
+        <p>{% if ok_email %}Hooray!  We can now send most unglued ebooks to you at {{ request.user.profile.kindle_email }}. Some ebooks are too big for us to send, though.
+        {% else %}<span class="yikes">{{ request.user.profile.kindle_email }} is probably not the right email for your Kindle; most Kindles use an @kindle.com email address. You can <a href="{% url kindle_config %}">change it</a>, but we'll try sending it anyway.</span> {% endif %}</p>
         {% if work %}
             <p>
                 We're now emailing you the ebook you wanted, <i><a href="{% url work work.id %}">{{ work.title }}</a></i>...

--- a/frontend/templates/kindle_config.html
+++ b/frontend/templates/kindle_config.html
@@ -33,7 +33,8 @@
                     (If you'd like to change your Kindle email, you can do so below. You'll need to download the book again.)
                 </p>
             {% else %}
-                <p>You already have a Kindle email on file with Unglue.it: {{ kindle_email }} .</p>
+                <p>You already have a Kindle email on file with Unglue.it: {{ kindle_email }} .
+                {% if not ok_email %}<span class="yikes">That's probably not the right email; most Kindles use an @kindle.com email address.</span> {% endif %}</p>
                 <p>You can change it below.</p>
                 <p>
                     If you emailed yourself an Unglue.it ebook and got a message from Amazon that the sender is not in your approved email list, add <b>notices@gluejar.com</b> to your <a href="http://www.amazon.com/myk#pdocSettings">Approved Personal Document Email List</a> under Personal Document Settings.
@@ -43,7 +44,7 @@
             <p>
                 Before your device or app can receive emails from Unglue.it, you'll have to add <b>notices@gluejar.com</b> to your <a href="http://www.amazon.com/myk#pdocSettings">Approved Personal Document Email List</a> under Personal Document Settings.
             </p>
-            <p>Then, enter your Kindle email address below:</p>
+            <p>Then, enter your Kindle email address below (most Kindles use an @kindle.com email address.):</p>
         {% endif %}
         {% if work %}
             <form method="post" action="{% url kindle_config_download work.id %}">{% csrf_token %}

--- a/frontend/views.py
+++ b/frontend/views.py
@@ -3150,7 +3150,11 @@ def kindle_config(request, work_id=None):
             template = "kindle_change_successful.html"
     else:
         form = KindleEmailForm()    
-    return render(request, template, {'form': form, 'work': work})
+    return render(request, template, {
+            'form': form, 
+            'work': work, 
+            'ok_email': request.user.profile.kindle_email and ('kindle' in request.user.profile.kindle_email),
+        })
 
 @require_POST
 @csrf_exempt


### PR DESCRIPTION
only valid kindle addresses we've seen not in kindle.com domain are
kindle.cn. Wanted to allow other addresses just in case.
