### PR TITLE
add case for correct user already has redeemed

### DIFF
--- a/frontend/views.py
+++ b/frontend/views.py
@@ -3019,8 +3019,12 @@ def receive_gift(request, nonce):
     # put nonce in session so we know that a user has redeemed a Gift
     request.session['gift_nonce'] = nonce
     if gift.used:
+        if request.user.is_authenticated():
+            #check that user hasn't redeemed the gift themselves
+            if (gift.acq.user.id == request.user.id) and not gift.acq.expired:
+                return HttpResponseRedirect( reverse('display_gift', args=[gift.id,'existing'] ))
         return render(request, 'gift_error.html', context )
-    if request.user.is_authenticated() and not gift.used:
+    if request.user.is_authenticated():
         user_license = work.get_user_license(request.user)
         if user_license and user_license.purchased:
             # check if previously purchased- there would be two user licenses if so.


### PR DESCRIPTION
This is designed to address the problem reported by John Jackson. He redeemed the gift on a kindle, but then was confused when he tried to redeem the gift on a different platform. We shouldn't report a failure if the redemption has succeeded.

John,

The JohnJackson account has a license for "Biodigital". You should be able to download it from that account, email address john@jackson-todd.com, or use "send to kindle". https://unglue.it/work/136615/

The gift was redeemed at 10:32 today. 

We've not tested this with a 4 year old Kindle, but at the very least, we should be able to make a smarter "already redeemed" page that tells you your account already has a license.

Thanks for the feedback, and please don't hesitate to contact support@gluejar.com if for some reason you can't download the book or log into the account.

Eric

On Mar 14, 2015, at 10:38 AM, johntpjackson@gmail.com wrote:

I tried, fat dumb and happy, to receive this book on my four year old Kindle.  So I fired up the Kindle’s clunky web browser and typed in the link from the notification e-mail https://unglue.it/receive_gift/fef41267abbbf2157f6be9ea53377108/  I’m pretty sure I got it right, but who knows…

I got an unglue.it web page that the page I was looking for doesn’t exist.

So, I try again, clicking on the link using Chrome on a Windows 8 PC.  Sign-up, create a password, find my way to the Notices page, click on the link, and I’m told that the gift has already been redeemed.

So, can I please redeem it, and then can you help me get it from PC to Kindle?

Thanks
John Jackson
