### PR TITLE
fix auth pipeline classes

### DIFF
--- a/core/auth.py
+++ b/core/auth.py
@@ -1,30 +1,33 @@
 import logging
 
-from social.pipeline.social_auth import (
-    social_user,
-    load_extra_data
-)
+from social.pipeline.social_auth import associate_by_email
 from social.apps.django_app.default.models import UserSocialAuth
+from social.exceptions import AuthAlreadyAssociated
 
-from regluit.core.models import TWITTER, FACEBOOK
+from regluit.core.models import TWITTER, FACEBOOK, UNGLUEITAR
 
 logger = logging.getLogger(__name__)
 
 
-def selectively_associate(backend, uid, user=None, *args, **kwargs):
-    """Not using Facebook or Twitter to authenticate a user.
+def selectively_associate_by_email(backend, details, user=None, *args, **kwargs):
     """
-    social_auth = UserSocialAuth.get_social_auth(backend.name, uid)
+    Associate current auth with a user with the same email address in the DB.
+    This pipeline entry is not 100% secure unless you know that the providers
+    enabled enforce email verification on their side, otherwise a user can
+    attempt to take over another user account by using the same (not validated)
+    email address on some provider.  
+    
+    Not using Facebook or Twitter to authenticate a user.
+    """
     if backend.name  in ('twitter', 'facebook'):
-        # not for authentication
-        return {'social_user': social_auth}
-    return social_user(backend, uid, user=None, *args, **kwargs)
+        return None
+    return associate_by_email(backend, details, user=None, *args, **kwargs)
 
 def facebook_extra_values( user,  extra_data):
     try:
         facebook_id = extra_data.get('id')
         user.profile.facebook_id = facebook_id
-        if user.profile.avatar_source is None:
+        if user.profile.avatar_source is None or user.profile.avatar_source is UNGLUEITAR:
             user.profile.avatar_source = FACEBOOK
         user.profile.save()
         return True
@@ -37,9 +40,9 @@ def twitter_extra_values( user, extra_data):
         twitter_id = extra_data.get('screen_name')
         profile_image_url = extra_data.get('profile_image_url_https')
         user.profile.twitter_id = twitter_id
-        if user.profile.avatar_source is None or user.profile.avatar_source is TWITTER:
+        if user.profile.avatar_source is None or user.profile.avatar_source in (TWITTER, UNGLUEITAR):
             user.profile.pic_url = profile_image_url
-        if user.profile.avatar_source is None:
+        if user.profile.avatar_source is None or user.profile.avatar_source is UNGLUEITAR:
             user.profile.avatar_source = TWITTER
         user.profile.save()
         return True
@@ -47,17 +50,28 @@ def twitter_extra_values( user, extra_data):
         logger.error(e)
         return False
         
-def deliver_extra_data(backend, details, response, uid, user, social_user=None,
-                    *args, **kwargs):
-    pipeline_data = load_extra_data(backend, details, response, uid, user, social_user=None,
-                    *args, **kwargs)
-
+def deliver_extra_data(backend,  user, social, *args, **kwargs):
     if backend.name is 'twitter':
-        twitter_extra_values( user, social_user.extra_data)
+        twitter_extra_values( user, social.extra_data)
     if backend.name is 'facebook':
-        facebook_extra_values( user, social_user.extra_data)
+        facebook_extra_values( user, social.extra_data)
 
 # following is needed because of length limitations in a unique constrain for MySQL
 def chop_username(username, *args, **kwargs):
     if username and len(username)>222:
         return {'username':username[0:222]}
+
+def selective_social_user(backend, uid, user=None, *args, **kwargs):
+    provider = backend.name
+    social = backend.strategy.storage.user.get_social_auth(provider, uid)
+    if social:
+        if user and social.user != user:
+            if backend.name not in ('twitter', 'facebook'):
+                msg = 'This {0} account is already in use.'.format(provider)
+                raise AuthAlreadyAssociated(backend, msg)
+        elif not user:
+            user = social.user
+    return {'social': social,
+            'user': user,
+            'is_new': user is None,
+            'new_association': False}

--- a/settings/common.py
+++ b/settings/common.py
@@ -239,7 +239,7 @@ SOCIAL_AUTH_PIPELINE = (
     'social.pipeline.social_auth.auth_allowed',
 
     # Checks if the current social-account is already associated in the site.
-    'social.pipeline.social_auth.social_user',
+    'regluit.core.auth.selective_social_user',
 
     # Make up a username for this person, appends a random string at the end if
     # there's any collision.
@@ -252,12 +252,9 @@ SOCIAL_AUTH_PIPELINE = (
     # Disabled by default.
     # 'social.pipeline.mail.mail_validation',
     
-    # don't use twitter or facebook to log in
-    'regluit.core.auth.selectively_associate',
-
     # Associates the current social details with another user account with
-    # a similar email address. Disabled by default.
-    'social.pipeline.social_auth.associate_by_email',
+    # a similar email address. don't use twitter or facebook to log in
+    'regluit.core.auth.selectively_associate_by_email',
 
     # Create a user account if we haven't found one yet.
     'social.pipeline.user.create_user',


### PR DESCRIPTION
1. the auth pipeline api had changed. 
2. I never updated the logic for picking an avatar when I changed the default avatar to "UNGLUITAR"

associating facebook and twitter should now work. correctly
