### PR TITLE
needed to have unicode to handle non-ascii names in Stripe

### DIFF
--- a/payment/stripelib.py
+++ b/payment/stripelib.py
@@ -905,8 +905,9 @@ class Processor(baseprocessor.Processor):
                         # do we have a flag to indicate production vs non-production? -- or does it matter?
                         # email RY whenever a new Customer created -- we probably want to replace this with some other
                         # more useful long tem action.
-                        send_mail("Stripe Customer (id {0};  description: {1}) created".format(ev_object.get("id"), ev_object.get("description")),
-                                  "Stripe Customer email: {0}".format(ev_object.get("email")),
+                        send_mail(u"Stripe Customer (id {0};  description: {1}) created".format(ev_object.get("id"),
+                                                                        ev_object.get("description")),
+                                  u"Stripe Customer email: {0}".format(ev_object.get("email")),
                                   "notices@gluejar.com",
                                   ["rdhyee@gluejar.com"])
                         logger.info("email sent for customer.created for {0}".format(ev_object.get("id")))


### PR DESCRIPTION
handle exception:

```
Traceback (most recent call last):

  File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 109, in get_response
    response = callback(request, *callback_args, **callback_kwargs)

  File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/views/decorators/csrf.py", line 77, in wrapped_view
    return view_func(*args, **kwargs)

  File "/opt/regluit/payment/views.py", line 263, in handleIPN
    return p.processIPN(request, module)

  File "/opt/regluit/payment/manager.py", line 49, in processIPN
    return mod.Processor().ProcessIPN(request)

  File "/opt/regluit/payment/stripelib.py", line 908, in ProcessIPN
    send_mail("Stripe Customer (id {0};  description: {1}) created".format(ev_object.get("id"), ev_object.get("description")),

UnicodeEncodeError: 'ascii' codec can't encode character u'\xed' in position 12: ordinal not in range(128)

```
