### PR TITLE
improve search results page

### DIFF
--- a/frontend/templates/search.html
+++ b/frontend/templates/search.html
@@ -106,7 +106,7 @@ $j(document).ready(function() {
         loader: '<img src="/static/images/loading.gif" alt="loading..." />',
         callback: function(p) {
             page += 1;
-            var url = "?q={{ q }}&page=" + page;
+            var url = "?q={{ q }}&gbo={{ gbo }}&page=" + page;
             $j.get(url, function(html) {
                 var view = $j(".listview").length > 0 ? "list" : "panel";
                 var results = $j(html).find(".book");
@@ -159,8 +159,14 @@ $j(document).ready(function() {
                     </div>
                     {% endfor %}
                 </div></div>
+              {% else %}
+              <div style="margin: 20px; font-size:14px">We couldn't find any matches in the Unglue.it database of free-licensed books.</div>
               {% endif %}
+                {% if not results and not campaign_works %}
+                <div style="margin: 20px; font-size:14px">Google Books couldn't find any matches either.</div>
+                {% else %}
                 <div class="content-block-heading">
+                    
                     <h2 class="content-heading"><a href="https://www.google.com/search?q={{q }}&amp;tbm=bks">Google Books</a> search results</span></h2>
                     
                       {% if not campaign_works %}
@@ -193,6 +199,7 @@ $j(document).ready(function() {
                     {% endfor %}
                 </div></div>
                 <div id="results-bottom"></div>
+                {% endif %}
             </div>    
         </div>
         </div>


### PR DESCRIPTION
when no local results, automatically invoke google books search. User is  now better informed what's happening.

this was a bit complicated because the endless-scroll search needs to either ask for the first page of google books  or the second page. so an added parameter 'gbo' keeps track of whether the search is "google books only"

also, when google books has no results, user is now informed of that.

This was bothering me!
