### PR TITLE
upgrading to Django 1.4.21

### DIFF
--- a/requirements_versioned.pip
+++ b/requirements_versioned.pip
@@ -1,4 +1,4 @@
-Django==1.4.19
+Django==1.4.21
 Fabric==1.6.0
 MySQL-python==1.2.3
 Pillow==2.5.3


### PR DESCRIPTION
upgrading to Django 1.4.21 should be simply a matter of changing the requirements file.  _fingers crossed_

https://docs.djangoproject.com/en/1.8/releases/1.4.20/
https://www.djangoproject.com/weblog/2015/jul/08/security-releases/
