### PR TITLE
update version of gitenberg.metadata in light of https://github.com/gitenberg-dev/metadata/pull/20

### DIFF
--- a/requirements_versioned.pip
+++ b/requirements_versioned.pip
@@ -41,7 +41,7 @@ django-tastypie==0.9.11
 feedparser==5.1.2
 freebase==1.0.8
 #gitenberg.metadata==0.1.6
-git+ssh://git@github.com/gitenberg-dev/metadata.git@e16b2f18b8d2842b8700914a96e756d887062bc1
+git+ssh://git@github.com/gitenberg-dev/metadata.git@0.1.8
 html5lib==1.0b3
 httplib2==0.7.5
 isodate==0.5.1


### PR DESCRIPTION
I reverted the metadata.yaml at Huck Finn and tried loading https://github.com/GITenberg/Adventures-of-Huckleberry-Finn_76/raw/master/metadata.yaml --> but got unsuccessful.  I'm guessing I will need to update unglue.it to make use of the new code (beyond just upping the version of gitenberg.metadata used.)
