### PR TITLE
fix occasional bug

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -1261,8 +1261,13 @@ class Work(models.Model):
             self.save()
             return self.selected_edition 
         except IndexError:
-            #should only happen if there are no editions for the work
-            return None
+            #should only happen if there are no editions for the work, 
+            #which can happen when works are being merged
+            try:
+                return WasWork.objects.get(was=self.id).work.preferred_edition
+            except WasWork.DoesNotExist:
+                #should not happen
+                return None
         
     def last_campaign_status(self):
         campaign = self.last_campaign()

--- a/core/tests.py
+++ b/core/tests.py
@@ -788,6 +788,20 @@ class SafeGetWorkTest(TestCase):
         work = safe_get_work(w2_id)
         self.assertEqual(work, w1)
         self.assertRaises(Http404, safe_get_work, 3)
+
+class WorkTests(TestCase):    
+    def test_preferred_edition(self):
+        w1 = models.Work.objects.create()
+        w2 = models.Work.objects.create()
+        ww = models.WasWork.objects.create(work=w1, was= w2.id)
+        e1 = models.Edition.objects.create(work=w1)
+        self.assertEqual(e1, w1.preferred_edition)
+        e2 = models.Edition.objects.create(work=w1)
+        w1.selected_edition=e2
+        w1.save()
+        self.assertEqual(e2, w1.preferred_edition)
+        self.assertEqual(e2, w2.preferred_edition)
+
         
 class DownloadPageTest(TestCase):
     def test_download_page(self):


### PR DESCRIPTION
I believe this bug occurs when a work is accessed while it is being merged with another work. Since all the code lives inside a rarely travesed except block, I think it's low risk, and if we stop seeing this error, we'll know it worked.

Traceback (most recent call last):

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 109, in get_response
   response = callback(request, _callback_args, *_callback_kwargs)

 File "/opt/regluit/frontend/views.py", line 441, in work
   'kwform': SubjectSelectForm()

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/shortcuts/**init**.py", line 44, in render
   return HttpResponse(loader.render_to_string(_args, *_kwargs),

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/loader.py", line 176, in render_to_string
   return t.render(context_instance)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 140, in render
   return self._render(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 134, in _render
   return self.nodelist.render(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 823, in render
   bit = self.render_node(node, context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 837, in render_node
   return node.render(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/loader_tags.py", line 123, in render
   return compiled_parent._render(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 134, in _render
   return self.nodelist.render(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 823, in render
   bit = self.render_node(node, context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 837, in render_node
   return node.render(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/loader_tags.py", line 62, in render
   result = block.nodelist.render(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 823, in render
   bit = self.render_node(node, context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 837, in render_node
   return node.render(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/defaulttags.py", line 478, in render
   output = self.nodelist.render(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 823, in render
   bit = self.render_node(node, context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 837, in render_node
   return node.render(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/defaulttags.py", line 478, in render
   output = self.nodelist.render(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 823, in render
   bit = self.render_node(node, context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 837, in render_node
   return node.render(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/defaulttags.py", line 275, in render
   match = condition.eval(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/defaulttags.py", line 825, in eval
   return self.value.resolve(context, ignore_failures=True)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 571, in resolve
   obj = self.var.resolve(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 721, in resolve
   value = self._resolve_lookup(context)

 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 772, in _resolve_lookup
   current = current()

 File "/opt/regluit/core/models.py", line 1163, in uses_google_cover
   return self.googlebooks_id

 File "/opt/regluit/core/models.py", line 1091, in googlebooks_id
   preferred_id=self.preferred_edition.googlebooks_id

AttributeError: 'NoneType' object has no attribute 'googlebooks_id'

<WSGIRequest
path:/work/146886/,
GET:<QueryDict: {}>,
POST:<QueryDict: {}>,
COOKIES:{'__utma': '192122478.2052756856.1440218657.1440218657.1440218657.1',
'__utmb': '192122478.4.10.1440218657',
'__utmc': '192122478',
'__utmt': '1',
'__utmz': '192122478.1440218657.1.1.utmcsr=google|utmccn=(organic)|utmcmd=organic|utmctr=(not%20provided)',
'sessionid': 'df61311a1037e264448d5fcd478c5f08'},
META:{'CSRF_COOKIE': 'JLT54PrLc5PsgkN76dVQeHkuTrirWDAE',
'DOCUMENT_ROOT': '/etc/apache2/htdocs',
'GATEWAY_INTERFACE': 'CGI/1.1',
'HTTPS': '1',
'HTTP_ACCEPT': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,_/_;q=0.8',
'HTTP_ACCEPT_ENCODING': 'gzip, deflate, sdch',
'HTTP_ACCEPT_LANGUAGE': 'es-419,es;q=0.8,en;q=0.6',
'HTTP_CONNECTION': 'keep-alive',
'HTTP_COOKIE': '__utmt=1; __utma=192122478.2052756856.1440218657.1440218657.1440218657.1; __utmb=192122478.4.10.1440218657; __utmc=192122478; __utmz=192122478.1440218657.1.1.utmcsr=google|utmccn=(organic)|utmcmd=organic|utmctr=(not%20provided); sessionid=df61311a1037e264448d5fcd478c5f08',
'HTTP_HOST': 'unglue.it',
'HTTP_REFERER': 'https://unglue.it/',
'HTTP_UPGRADE_INSECURE_REQUESTS': '1',
'HTTP_USER_AGENT': 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.155 Safari/537.36',
'PATH_INFO': u'/work/146886/',
'PATH_TRANSLATED': '/opt/regluit/deploy/regluit.wsgi/work/146886/',
'QUERY_STRING': '',
'REMOTE_ADDR': '190.49.60.125',
'REMOTE_PORT': '24711',
'REQUEST_METHOD': 'GET',
'REQUEST_URI': '/work/146886/',
'SCRIPT_FILENAME': '/opt/regluit/deploy/regluit.wsgi',
'SCRIPT_NAME': u'',
'SCRIPT_URI': 'https://unglue.it/work/146886/',
'SCRIPT_URL': '/work/146886/',
'SERVER_ADDR': '10.32.166.130',
'SERVER_ADMIN': '[no address given]',
'SERVER_NAME': 'unglue.it',
'SERVER_PORT': '443',
'SERVER_PROTOCOL': 'HTTP/1.1',
'SERVER_SIGNATURE': '<address>Apache/2.2.22 (Ubuntu) Server at unglue.it Port 443</address>\n',
'SERVER_SOFTWARE': 'Apache/2.2.22 (Ubuntu)',
'SSL_TLS_SNI': 'unglue.it',
'mod_wsgi.application_group': 'unglue.it|',
'mod_wsgi.callable_object': 'application',
'mod_wsgi.handler_script': '',
'mod_wsgi.input_chunked': '0',
'mod_wsgi.listener_host': '',
'mod_wsgi.listener_port': '443',
'mod_wsgi.process_group': '',
'mod_wsgi.request_handler': 'wsgi-script',
'mod_wsgi.script_reloading': '1',
'mod_wsgi.version': (3, 3),
'wsgi.errors': <mod_wsgi.Log object at 0x7fd08c4f3ab0>,
'wsgi.file_wrapper': <built-in method file_wrapper of mod_wsgi.Adapter object at 0x7fd09efae288>,
'wsgi.input': <mod_wsgi.Input object at 0x7fd08c4f3df0>,
'wsgi.multiprocess': True,
'wsgi.multithread': True,
'wsgi.run_once': False,
'wsgi.url_scheme': 'https',
'wsgi.version': (1, 1)}>
