### PR TITLE
fix relator model

### DIFF
--- a/core/migrations/0072_auto__add_relator__add_relation__add_field_subject_authority.py
+++ b/core/migrations/0072_auto__add_relator__add_relation__add_field_subject_authority.py
@@ -296,11 +296,11 @@ class Migration(SchemaMigration):
             'name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'})
         },
         'core.relator': {
-            'Meta': {'object_name': 'Relator', 'db_table': "'core_subject_works'"},
+            'Meta': {'object_name': 'Relator', 'db_table': "'core_author_editions'"},
             'author': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['core.Author']"}),
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'relation': ('django.db.models.fields.related.ForeignKey', [], {'default': '1', 'to': "orm['core.Relation']"}),
-            'work': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'author'", 'to': "orm['core.Work']"})
+            'edition': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'author'", 'to': "orm['core.Edition']"})
         },
         'core.rightsholder': {
             'Meta': {'object_name': 'RightsHolder'},


### PR DESCRIPTION
this error was causing subsequent core migrations to fail.
the models object in migrations is only used by south to decide whether the models in the database need to be migrated from the models in models.py.

The see the bug/verify the fix, try '''django-admin.py schemamigration core --auto''' without changing any models. 

this should get merged before other PR's but there's no need to deploy it.

The error must have occurred due to changing the migration by hand instead of regenerating the migration with south.
