### PR TITLE
upgrade and config ckedit

### DIFF
--- a/requirements_versioned.pip
+++ b/requirements_versioned.pip
@@ -21,8 +21,7 @@ celery==3.0.9
 # but having distribute in requirements starting to cause problems
 # distribute==0.6.28
 django-celery==3.0.9
-#django-ckeditor==3.6.2.1
-git+ssh://git@github.com/Gluejar/django-ckeditor.git@3.6.2.1.post20131230
+django-ckeditor==4.5.1
 #django-email-change==0.2.3
 git+git://github.com/novagile/django-email-change.git@0d7cb91b987a0505a9c4bde126d452233dea266d
 django-endless-pagination==2.0

--- a/settings/common.py
+++ b/settings/common.py
@@ -30,6 +30,10 @@ MEDIA_ROOT = ''
 # Examples: "http://media.lawrence.com/media/", "http://example.com/media/"
 MEDIA_URL = '/media/'
 
+# set once instead of in all the templates
+JQUERY_HOME = "/static/js/jquery-1.7.1.min.js"
+JQUERY_UI_HOME = "/static/js/jquery-ui-1.8.16.custom.min.js"
+
 CKEDITOR_UPLOAD_PATH = ''
 CKEDITOR_RESTRICT_BY_USER = True
 CKEDITOR_CONFIGS = {
@@ -37,12 +41,14 @@ CKEDITOR_CONFIGS = {
         'width': 700,
         'toolbar': [
             ['Cut','Copy','Paste', 'PasteFromWord', '-', 'Undo', 'Redo', '-', 'Source'],
-            ['Bold', 'Italic', '-', 'NumberedList','BulletedList', '-','Blockquote'],
+            ['Bold', 'Italic', 'RemoveFormat', '-', 'NumberedList','BulletedList', '-','Blockquote'],
             ['Find','Replace','-', 'Scayt'],
-            ['Link', 'Unlink', '-', 'Image', 'HorizontalRule']
+            ['Link', 'Unlink', '-', 'Image','HorizontalRule']
          ],
+         'disallowedContent': '*[style]{font*} script style *[on*]{*}',
     },
 }
+CKEDITOR_JQUERY_URL=JQUERY_HOME
 
 # Absolute path to the directory static files should be collected to.
 # Don't put anything in this directory yourself; store your static files
@@ -311,10 +317,6 @@ MAX_CC_DATE = datetime.date( 2099,12,31)
 TEST_RUNNER = "djcelery.contrib.test_runner.CeleryTestSuiteRunner"
 import djcelery
 djcelery.setup_loader()
-
-# set once instead of in all the templates
-JQUERY_HOME = "/static/js/jquery-1.7.1.min.js"
-JQUERY_UI_HOME = "/static/js/jquery-ui-1.8.16.custom.min.js"
 
 # Mailchimp archive JavaScript URL
 CAMPAIGN_ARCHIVE_JS = "http://us2.campaign-archive1.com/generate-js/?u=15472878790f9faa11317e085&fid=28161&show=10"


### PR DESCRIPTION
ckedit has developed a lot since we started using. have updated to 

don't use pip install -U, use uninstall and install. The most current version, v5.0.2 doesn't seem to work with dj1.4.22, I bumped to v4.5.1
run collectstatic afterwards.

I wanted to prevent pasted style from being inserted into description. I decided the main thing that looked bad was overriding our font size and styles, so I left it at that. The easiest way to do this turned out to be using automatic content filtering added in ckedit 4.1.

To test, do an edition edit and past in styled text into description. ckedit is also used in campaign edit.

We had been using a customized version - that fixed code related to depending on extensions in upload file names that's no longer present and has been fixed.
