### PR TITLE
set the default

### DIFF
--- a/frontend/views.py
+++ b/frontend/views.py
@@ -493,7 +493,7 @@ def edition_uploads(request, edition_id):
         })
     return render(request, 'edition_uploads.html', context )
 
-def add_subject(subject_name,work, authority=None):
+def add_subject(subject_name,work, authority=''):
     try:
         subject= models.Subject.objects.get(name=subject_name)
     except models.Subject.DoesNotExist:


### PR DESCRIPTION
The bug here is subtle. In creating a new edition, the UI doesn't let you create a new subject (though it's supposed to; I think this is a bug in the version of django-selectable we're using.) But if you select a second subject that doesn't need to be created, when you save the edition, an exception is thrown, because the newly created edition slips through and the subject creator was setting the default authority incorrectly.

This PR patches the exception, but doesn't try to fix the UI that tries to stop you from creating a new subject.

To reproduce the bug, try creating an edition with a random string as the subject. then add a good subject- like "fiction". Then save the edition.
