### PR TITLE
fix edit permissions

### DIFF
--- a/frontend/templates/edition_display.html
+++ b/frontend/templates/edition_display.html
@@ -36,7 +36,9 @@
                     <a href="{% url 'new_edition' work_id edition.id %}">Edit this edition</a><br />
                 {% else %}{% if user in work.last_campaign.managers.all %}
                     <a href="{% url 'new_edition' work_id edition.id %}">Edit this edition</a><br />
-                {% endif %}{% endif %}
+                {% else %}{% if user.rights_holder.count and not work.last_campaign %}
+                    <a href="{% url 'new_edition' work_id edition.id %}">Edit this edition</a><br />
+                {% endif %}{% endif %}{% endif %}
                 {% if user.is_authenticated %}
                     <a href="{% url 'manage_ebooks' edition.id %}">Add ebook link</a><br />
                 {% endif %}

--- a/frontend/views.py
+++ b/frontend/views.py
@@ -523,7 +523,7 @@ def new_edition(request, work_id, edition_id, by=None):
     elif work and work.last_campaign():
         if request.user in work.last_campaign().managers.all():
             admin = True
-    elif work==None and request.user.rights_holder.count():
+    elif request.user.rights_holder.count() and (work == None or not work.last_campaign()): # allow rights holders to edit unless there is a campaign
         admin = True
     if edition_id:
         try:


### PR DESCRIPTION
we were letting rightsholders create editions but not edit them, and
the display of the link didn't match the edit permission. now
rightsholders can edit any edition for any work not in a campaign.

please push this promptly, it's affecting a new rightsholder
