### PR TITLE
no, don't deactivate other ebooks

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -1011,6 +1011,7 @@ class Campaign(models.Model):
                 url= settings.BASE_URL_SECURE + reverse('download_campaign',args=[self.work.id,format]),
                 )
         old_ebooks = Ebook.objects.exclude(pk=ebook.pk).filter(
+                edition=self.work.preferred_edition
                 format=format, 
                 rights=self.license, 
                 provider="Unglue.it",


### PR DESCRIPTION
when biodigital was unglued, all epub and mobi CC BY-SA ebooks were deactivated by mistake. I have reactivated them by hand in admin.
