### PR TITLE
try removing DefaultStorageFinder -- will this break the questionnaire?

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -84,7 +84,7 @@ STATICFILES_DIRS = (
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-    'django.contrib.staticfiles.finders.DefaultStorageFinder',
+    # 'django.contrib.staticfiles.finders.DefaultStorageFinder',
 )
 
 # Make this unique, and don't share it with anybody.


### PR DESCRIPTION
we're starting to encounter problems with collectstatic on just and production....For some reason, the following file is being picked up by collectstatic (on just anyhow):
(u'ebf/0013be081ea0ad9e54bc06b8fe6a53ba.pdf', u'ebf/0013be081ea0ad9e54bc06b8fe6a53ba.pdf', <django.core.files.storage.DefaultStorage object at 0x242de90)>
Do you have a good understanding of static files, e.g., https://github.com/Gluejar/regluit/blob/574854ec5a462c0f03708e32264164991cdf2fe5/settings/common.py#L84-L88:
STATICFILES_FINDERS = (
    'django.contrib.staticfiles.finders.FileSystemFinder',
    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
    'django.contrib.staticfiles.finders.DefaultStorageFinder',
)
