### PR TITLE
add googlebooks virtual urls to disallow

### DIFF
--- a/frontend/templates/robots.txt
+++ b/frontend/templates/robots.txt
@@ -4,6 +4,7 @@ User-agent: *
 Disallow: /accounts/
 Disallow: /feedback/
 Disallow: /socialauth/
+Disallow: /googlebooks/
 {% else %}
 User-agent: *
 Disallow: /


### PR DESCRIPTION
after we added author links, robots started creating db entries by
following links in search page
