### PR TITLE
implement indirectAcquisition element

### DIFF
--- a/api/opds.py
+++ b/api/opds.py
@@ -89,11 +89,19 @@ def work_node(work, facet=None):
         link_node = etree.Element("link")
         
         # ebook.download_url is an absolute URL with the protocol, domain, and path baked in
-        link_rel = "http://opds-spec.org/acquisition/open-access" if ebook.is_direct() else "http://opds-spec.org/acquisition"
+        link_rel = "http://opds-spec.org/acquisition/open-access" 
         link_node.attrib.update({"href":add_query_component(ebook.download_url, "feed=opds"),
-                                 "type":FORMAT_TO_MIMETYPE.get(ebook.format, ""),
-                                 "rel":link_rel,
-                                 "{http://purl.org/dc/terms/}rights": str(ebook.rights)})
+                                     "rel":link_rel,
+                                     "{http://purl.org/dc/terms/}rights": str(ebook.rights)})
+        if ebook.is_direct(): 
+            link_node.attrib["type"] = FORMAT_TO_MIMETYPE.get(ebook.format, "")
+        else:
+            """ indirect acquisition, i.e. google books """
+            link_node.attrib["type"] = "text/html"
+            indirect = etree.Element("{http://opds-spec.org/}indirectAcquisition",)
+            indirect.attrib["type"] = FORMAT_TO_MIMETYPE.get(ebook.format, "")
+            link_node.append(indirect)
+            
         node.append(link_node)
         
     # get the cover -- assume jpg?

--- a/core/models.py
+++ b/core/models.py
@@ -2131,7 +2131,7 @@ class Ebook(models.Model):
         return settings.BASE_URL_SECURE + reverse('download_ebook',args=[self.id])
 
     def is_direct(self):
-        return self.provider!='Google Books'
+        return self.provider not in ('Google Books', 'Project Gutenberg')
     
     def __unicode__(self):
         return "%s (%s from %s)" % (self.edition.title, self.format, self.provider)


### PR DESCRIPTION
Eric,

Here's an example to motivate this discussion:

https://unglue.it/api/opds/all/?work=66967

Here's the link from that feed that's causing me problems:
<link href="https://unglue.it/download_ebook/497/?feed=opds" type="application/epub+zip" dcterms:rights="PD-US" rel="http://opds-spec.org/acquisition/open-access"/>
This tells me that if I hit https://unglue.it/download_ebook/497/?feed=opds 
I'll get an EPUB. Unfortunately this isn't quite true. That URL redirects to 
http://www.gutenberg.org/cache/epub/6900/pg6900.epub, and Project Gutenberg won't let you 
just download a book like that. It makes you go through a click-through first.
From our perspective this is manageable. The OPDS feed said we would get an EPUB, but
we actually got an HTML page. We don't mirror HTML versions of books, so we just skip it. 
We already have all the Gutenberg books, so nothing is lost.
Except... hitting Gutenberg pages for all these books makes Gutenberg get sick of us and ban our IP. This isn't good for us because we do need to access Gutenberg's website for other purposes. 

I can avoid getting banned by making HEAD requests to all acquisition links on unglue.it, and ignoring the ones that redirect to gutenberg.org, but the OPDS spec offers a way to explain what's going on here without requiring any special requests at all: the indirectAcquisition element.

http://opds-spec.org/specs/opds-catalog-1-1-20110627/#The_opds_indirectAcquisition_Element

The indirectAcquisition element lets you lay out a multi-step process for acquiring a book. We use it in Simplified to indicate that following a certain link will get you an OPDS entry, which you can process (using the normal rules for processing OPDS entries) to get an ACSM file, which you can process (using the normal rules for processing ACSM files) to get an EPUB.
    <link href="https://circulation.librarysimplified.org/works/Overdrive/Overdrive%20ID/0955ddc9-f024-4549-947b-f1f487898567/borrow" rel="http://opds-spec.org/acquisition/borrow" type="application/atom+xml;type=entry;profile=opds-catalog">
      <opds:indirectAcquisition type="vnd.adobe/adept+xml">
        <opds:indirectAcquisition type="application/epub+zip"/>
      /opds:indirectAcquisition
    </link>

Of relevance to you, this construct can also express the idea that you might have to do a click-through to acquire a book:

```
<link href="https://unglue.it/download_ebook/497/?feed=opds" type="text/html">
 <opds:indirectAcquisition type="application/epub+zip"/>
</link>
```

Since our client isn't a web browser, it isn't able to process an HTML file using the normal rules. A tag like this would let us know ahead of time what's behind that link, so we know we won't be able to get to the EPUB and we won't follow the link and get banned.

What do you think?

Leonard
