### PR TITLE
modify script used to dump sql to include table definition for core_key

### DIFF
--- a/deploy/dump_db_prod.sh
+++ b/deploy/dump_db_prod.sh
@@ -1,2 +1,21 @@
-#!/bin/sh
-mysqldump -h production.cboagmr25pjs.us-east-1.rds.amazonaws.com -u root --password=unglue1t --ignore-table=unglueit.core_key unglueit
+#!/bin/bash
+PASSWORD=unglue1t
+HOST=production.cboagmr25pjs.us-east-1.rds.amazonaws.com
+USER=root
+DATABASE=unglueit
+DB_FILE=unglue.it.sql
+EXCLUDED_TABLES=(
+  core_key
+)
+
+IGNORED_TABLES_STRING=''
+for TABLE in "${EXCLUDED_TABLES[@]}"
+do :
+   IGNORED_TABLES_STRING+=" --ignore-table=${DATABASE}.${TABLE}"
+done
+
+echo "Dump structure"
+mysqldump --host=${HOST} --user=${USER} --password=${PASSWORD} --single-transaction --no-data ${DATABASE} > ${DB_FILE}
+
+echo "Dump content"
+mysqldump --host=${HOST} --user=${USER} --password=${PASSWORD}  --no-create-info ${DATABASE} ${IGNORED_TABLES_STRING} >> ${DB_FILE}

--- a/fabfile.py
+++ b/fabfile.py
@@ -37,7 +37,7 @@ def get_dump():
     """Dump the current db on remote server and scp it over to local machine.
     Note:  web1 has been hardcoded here to represent the name of the unglue.it server
     """
-    run("./dump.sh > unglue.it.sql ")
+    run("./dump.sh")
     run("gzip -f unglue.it.sql")
     local("scp web1:/home/ubuntu/unglue.it.sql.gz .")
     local("gunzip -f unglue.it.sql.gz")


### PR DESCRIPTION
I was not including the sqldump for unglue.it the definition of the core_key database (which I had excluded from the dump).
