### PR TITLE
[WIP] work.authors() returns list of all authors

### DIFF
--- a/frontend/views.py
+++ b/frontend/views.py
@@ -2826,7 +2826,7 @@ def lockss(request, work_id):
         ebooks = work.ebooks().filter(edition__unglued=True)
     except:
         ebooks = None
-    authors = work.authors.all()
+    authors = work.authors()
     
     return render(request, "lockss.html", {'work':work, 'ebooks':ebooks, 'authors':authors})
     


### PR DESCRIPTION
Exception we ran into this morning:

```
Internal Server Error: /work/76348/lockss/
Traceback (most recent call last):
  File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/regluit/frontend/views.py", line 2829, in lockss
    authors = work.authors.all()
AttributeError: 'function' object has no attribute 'all'

Request repr(): 
<WSGIRequest
path:/work/76348/lockss/,
GET:<QueryDict: {}>,
POST:<QueryDict: {}>,
COOKIES:{'__utma': '192122478.1335049409.1474649420.1474649420.1474649420.1',
 '__utmb': '192122478.13.10.1474649420',
 '__utmc': '192122478',
 '__utmt': '1',
 '__utmz': '192122478.1474649420.1.1.utmcsr=(direct)|utmccn=(direct)|utmcmd=(none)'},
META:{u'CSRF_COOKIE': u'9R4dz2eQ2dDmAq6ShzTOfJWWxBvkwP4w',
 'DOCUMENT_ROOT': '/etc/apache2/htdocs',
 'GATEWAY_INTERFACE': 'CGI/1.1',
 'HTTPS': '1',
 'HTTP_ACCEPT': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
 'HTTP_ACCEPT_ENCODING': 'gzip, deflate, br',
 'HTTP_ACCEPT_LANGUAGE': 'en-US,en;q=0.5',
 'HTTP_CONNECTION': 'keep-alive',
 'HTTP_COOKIE': '__utma=192122478.1335049409.1474649420.1474649420.1474649420.1; __utmb=192122478.13.10.1474649420; __utmc=192122478; __utmz=192122478.1474649420.1.1.utmcsr=(direct)|utmccn=(direct)|utmcmd=(none); __utmt=1',
 'HTTP_HOST': 'unglue.it',
 'HTTP_REFERER': 'https://unglue.it/',
 'HTTP_UPGRADE_INSECURE_REQUESTS': '1',
 'HTTP_USER_AGENT': 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:49.0) Gecko/20100101 Firefox/49.0',
 'PATH_INFO': u'/work/76348/lockss/',
 'PATH_TRANSLATED': '/opt/regluit/deploy/regluit.wsgi/work/76348/lockss/',
 'QUERY_STRING': '',
 'REMOTE_ADDR': '171.66.236.95',
 'REMOTE_PORT': '39418',
 'REQUEST_METHOD': 'GET',
 'REQUEST_URI': '/work/76348/lockss/',
 'SCRIPT_FILENAME': '/opt/regluit/deploy/regluit.wsgi',
 'SCRIPT_NAME': u'',
 'SCRIPT_URI': 'https://unglue.it/work/76348/lockss/',
 'SCRIPT_URL': '/work/76348/lockss/',
 'SERVER_ADDR': '10.171.72.166',
 'SERVER_ADMIN': '[no address given]',
 'SERVER_NAME': 'unglue.it',
 'SERVER_PORT': '443',
 'SERVER_PROTOCOL': 'HTTP/1.1',
 'SERVER_SIGNATURE': '<address>Apache/2.2.22 (Ubuntu) Server at unglue.it Port 443</address>\n',
 'SERVER_SOFTWARE': 'Apache/2.2.22 (Ubuntu)',
 'SSL_TLS_SNI': 'unglue.it',
 'mod_wsgi.application_group': 'unglue.it|',
 'mod_wsgi.callable_object': 'application',
 'mod_wsgi.handler_script': '',
 'mod_wsgi.input_chunked': '0',
 'mod_wsgi.listener_host': '',
 'mod_wsgi.listener_port': '443',
 'mod_wsgi.process_group': '',
 'mod_wsgi.request_handler': 'wsgi-script',
 'mod_wsgi.script_reloading': '1',
 'mod_wsgi.version': (3, 3),
 'wsgi.errors': <mod_wsgi.Log object at 0x7f4c4b3a1e30>,
 'wsgi.file_wrapper': <built-in method file_wrapper of mod_wsgi.Adapter object at 0x7f4c4b2c06c0>,
 'wsgi.input': <mod_wsgi.Input object at 0x7f4c4b3a1d30>,
 'wsgi.multiprocess': True,
 'wsgi.multithread': True,
 'wsgi.run_once': False,
 'wsgi.url_scheme': 'https',
 'wsgi.version': (1, 1)}>
```

I've not tested this yet...does this look right?
