### PR TITLE
tighten ebook notifications

### DIFF
--- a/core/models/bibmodels.py
+++ b/core/models/bibmodels.py
@@ -433,8 +433,11 @@ class Work(models.Model):
             for ebook in self.ebooks():
                 return ebook
 
-    def wished_by(self):
-        return User.objects.filter(wishlist__works__in=[self])
+    def wished_by(self, excluding=None):
+        if excluding:
+            return User.objects.filter(wishlist__wishes__work=self).exclude(wishlist__wishes__created__range=excluding)
+        else:
+            return User.objects.filter(wishlist__wishes__work=self)
 
     def update_num_wishes(self):
         self.num_wishes = self.wishes.count()


### PR DESCRIPTION
The 0006_auto_20160818_1809 migration created inactive ebooks for
campaign books. These new ebooks triggered user notifications. Now the
new ebook notification is only sent if there's a new _active_ ebook. Also, it's
been a known issue #76568402 that we should stop notifying ebooks for
users who fave newly available ebooks.
