### PR TITLE
work might not have an ebook

### DIFF
--- a/api/opds.py
+++ b/api/opds.py
@@ -86,7 +86,7 @@ def work_node(work, facet=None):
     ebooks = facet.filter_model("Ebook",work.ebooks()) if facet else work.ebooks()
     versions = set()
     for ebook in ebooks:
-        if not updated:
+        if updated is None:
             # most recent ebook, first ebook in loop
             updated = ebook.created.isoformat()
             node.append(text_node('updated', updated))


### PR DESCRIPTION
the ahrefs bot encountered a feed where the work did not have an ebook:

Internal Server Error: /api/opds/creative_commons/
Traceback (most recent call last):
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
   response = wrapped_callback(request, _callback_args, *_callback_kwargs)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/views/generic/base.py", line 71, in view
   return self.dispatch(request, _args, *_kwargs)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/views/generic/base.py", line 89, in dispatch
   return handler(request, _args, *_kwargs)
 File "/opt/regluit/api/views.py", line 185, in get
   return HttpResponse(facet_class.feed(page,order_by),
 File "/opt/regluit/api/opds.py", line 195, in feed
   return opds_feed_for_works(self, page=page, order_by=order_by)
 File "/opt/regluit/api/opds.py", line 327, in opds_feed_for_works
   node = work_node(work, facet=the_facet.facet_object)
 File "/opt/regluit/api/opds.py", line 84, in work_node
   node.append(text_node('updated', work.first_ebook().created.isoformat()))
AttributeError: 'NoneType' object has no attribute 'created'

This fix changes the feed so that the updated node is only emitted if there is an ebook.

I was not able to reproduce the ahrefs error, suggesting that there may have only been a transient situation where the opds feed returns works without ebooks. but the new code is also more efficient, as it eliminates a redundant call to the db.
