### PR TITLE
change target of links to PG/DOAB and add facet links to explore panel

### DIFF
--- a/frontend/templates/explore.html
+++ b/frontend/templates/explore.html
@@ -17,13 +17,19 @@
                             {% endif %}
                                 <li><a href="{% url 'free' %}"><span>Free eBooks!</span></a>
                                 {% if work %}
-                                <ul class="menu level3">
-                                    {% for subject in work.subjects.all %}
-                                    {% if subject.is_visible and subject.free_works.1 %}
-                                    <li><a href="{% url 'faceted_list' subject.kw %}"><span>{{ subject }}</span></a></li>
-                                    {% endif %}
-                                    {% endfor %}
-                                </ul>
+                                    <ul class="menu level3">
+                                        {% if work.doab %}
+                                            <li><a href="{% url 'faceted_list' 'id/doab' %}?order_by=popular">Books in DOAB</a></li>
+                                        {% endif %}
+                                        {% if work.gtbg %}
+                                            <li><a href="{% url 'faceted_list' 'id/gtbg' %}?order_by=popular">Books in Project Gutenberg</a></li>
+                                        {% endif %}
+                                        {% for subject in work.subjects.all %}
+                                            {% if subject.is_visible and subject.free_works.1 %}
+                                                <li><a href="{% url 'faceted_list' subject.kw %}"><span>{{ subject }}</span></a></li>
+                                            {% endif %}
+                                        {% endfor %}
+                                    </ul>
                                 {% endif %}
                                 </li>
                                 <li><a href="{% url 'campaign_list' 'ending' %}"><span>Active Campaigns</span></a></li>

--- a/frontend/templates/work.html
+++ b/frontend/templates/work.html
@@ -291,12 +291,12 @@
                                     {% endfor %}
                                     {% if work.doab %}
                                     <p>
-                                    This book is included in <a href="{% url 'faceted_list' 'id/doab' %}?order_by=popular">DOAB</a>.
+                                    This book is included in <a href="http://www.doabooks.org/doab?func=search&query=rid%3A{{ work.doab }}">DOAB</a>.
                                     </p>
                                     {% endif %}
                                     {% if work.gtbg %}
                                     <p>
-                                    This book is included in <a href="{% url 'faceted_list' 'id/gtbg' %}?order_by=popular">Project Gutenberg</a>.
+                                    This book is included in <a href="https://www.gutenberg.org/ebooks/{{ work.gtbg }}">Project Gutenberg</a>.
                                     </p>
                                     {% endif %}
                                     </div>


### PR DESCRIPTION
I didn't like the way the link in the abstract text pointed to our facet and changed it to point to the referenced collection. The facet link belongs in the explore area.