### PR TITLE
fix truncated image file problems

### DIFF
--- a/core/models/bibmodels.py
+++ b/core/models/bibmodels.py
@@ -10,6 +10,7 @@ import unicodedata
 from urlparse import urlparse
 
 from sorl.thumbnail import get_thumbnail
+from PIL import ImageFile
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -41,6 +42,9 @@ from regluit.core.parameters import (
     THANKED,
     THANKS,
 )
+
+# fix truncated file problems per http://stackoverflow.com/questions/12984426/python-pil-ioerror-image-file-truncated-with-big-images
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 logger = logging.getLogger(__name__)
 good_providers = ('Internet Archive', 'Unglue.it', 'Github', 'OAPEN Library')

--- a/requirements_versioned.pip
+++ b/requirements_versioned.pip
@@ -1,7 +1,7 @@
 Django==1.8.14
 Fabric==1.6.0
 MySQL-python==1.2.5
-Pillow==2.5.3
+Pillow==3.4.2
 PyJWT==1.4.1
 PyPDF2==1.23
 PyGithub==1.15.0


### PR DESCRIPTION
solution found here:

update Pillow while we're at it.

simple code that shows the error:

work =  Work.objects.get(id=195756)
update_cover_doab(18456, work.selected_edition)
work.selected_edition.cover_image_thumbnail()

Here's the stack trace from an example error:
Internal Server Error: /work/195756/
Traceback (most recent call last):
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
   response = wrapped_callback(request, *callback_args, **callback_kwargs)
 File "/opt/regluit/frontend/views.py", line 420, in work
   'kwform': SubjectSelectForm()
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/shortcuts.py", line 67, in render
   template_name, context, request=request, using=using)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/loader.py", line 99, in render_to_string
   return template.render(context, request)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/backends/django.py", line 74, in render
   return self.template.render(context)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 210, in render
   return self._render(context)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 202, in _render
   return self.nodelist.render(context)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 905, in render
   bit = self.render_node(node, context)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 919, in render_node
   return node.render(context)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/loader_tags.py", line 135, in render
   return compiled_parent._render(context)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 202, in _render
   return self.nodelist.render(context)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 905, in render
   bit = self.render_node(node, context)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 919, in render_node
   return node.render(context)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/loader_tags.py", line 65, in render
   result = block.nodelist.render(context)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 905, in render
   bit = self.render_node(node, context)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 919, in render_node
   return node.render(context)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/defaulttags.py", line 576, in render
   return self.nodelist.render(context)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 905, in render
   bit = self.render_node(node, context)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 919, in render_node
   return node.render(context)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/defaulttags.py", line 576, in render
   return self.nodelist.render(context)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 905, in render
   bit = self.render_node(node, context)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 919, in render_node
   return node.render(context)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/defaulttags.py", line 329, in render
   return nodelist.render(context)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 905, in render
   bit = self.render_node(node, context)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 919, in render_node
   return node.render(context)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 959, in render
   output = self.filter_expression.resolve(context)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 648, in resolve
   obj = self.var.resolve(context)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 789, in resolve
   value = self._resolve_lookup(context)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/django/template/base.py", line 849, in _resolve_lookup
   current = current()
 File "/opt/regluit/core/models/bibmodels.py", line 220, in cover_image_thumbnail
   return self.preferred_edition.cover_image_thumbnail()
 File "/opt/regluit/core/models/bibmodels.py", line 809, in cover_image_thumbnail
   im = get_thumbnail(self.cover_image, '128', crop='noop', quality=95)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/sorl/thumbnail/shortcuts.py", line 8, in get_thumbnail
   return default.backend.get_thumbnail(file_, geometry_string, **options)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/sorl/thumbnail/base.py", line 125, in get_thumbnail
   thumbnail)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/sorl/thumbnail/base.py", line 157, in _create_thumbnail
   image = default.engine.create(source_image, geometry, options)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/sorl/thumbnail/engines/base.py", line 21, in create
   image = self.colorspace(image, geometry, options)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/sorl/thumbnail/engines/base.py", line 53, in colorspace
   return self._colorspace(image, colorspace)
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/sorl/thumbnail/engines/pil_engine.py", line 101, in _colorspace
   return image.convert('RGB')
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/PIL/Image.py", line 822, in convert
   self.load()
 File "/opt/regluit/ENV/local/lib/python2.7/site-packages/PIL/ImageFile.py", line 218, in load
   raise IOError("image file is truncated (%d bytes not processed)" % len(b))
IOError: image file is truncated (12 bytes not processed)

