### PR TITLE
incorrect usage of purchased tag

### DIFF
--- a/frontend/templates/work_action.html
+++ b/frontend/templates/work_action.html
@@ -1,6 +1,4 @@
 {% load humanize %}
-{% purchased %}
-{% lib_acqs %}
 <div class="clearfix">
     {% if status == 'ACTIVE' %}
       {% if work.last_campaign.type == 1 %}


### PR DESCRIPTION
Not sure why the error (tag not loaded) didn't occur on my local
machine.

the purchased tag is executed on the work template, no need to execute
on work_action. It adds values into the context object.