### PR TITLE
load springer improvements

### DIFF
--- a/core/management/commands/load_books_springer.py
+++ b/core/management/commands/load_books_springer.py
@@ -4,9 +4,9 @@ from regluit.core.loaders.springer import load_springer
 
 class Command(BaseCommand):
     help = "load books from springer open"
-    args = "<pages>"
+    args = "<startpage> <endpage>"
 
 
-    def handle(self, pages, **options):
-        books = load_springer(int(pages))        
+    def handle(self, startpage, endpage=0, **options):        
+        books = load_springer(int(startpage), int(endpage))       
         print "loaded {} books".format(len(books))


### PR DESCRIPTION
We've loaded about half the Springer Open books catalog, adding 20
books at a time. I wanted to load page 23 of results without having to
load pages 1-22. Also added some exception handling.