### PR TITLE
Dj 1.9 deprecated in 1.7

### DIFF
--- a/booxtream/__init__.py
+++ b/booxtream/__init__.py
@@ -5,25 +5,24 @@ from urllib import quote
 from functools import partial
 from xml.etree import ElementTree
 
+from django.apps import apps
 
 from . exceptions import BooXtreamError
-from . models import Boox
-
 
 class BooXtream(object):
     """ ``apikey``
 
-          The API key for your BooXtream account, obtained from BooXtream. Defaults to using 
+          The API key for your BooXtream account, obtained from BooXtream. Defaults to using
           settings.BOOXTREAM_API_KEY
 
         ``apiuser``
 
-          The username key for your BooXtream account, obtained from BooXtream. Defaults to using 
+          The username key for your BooXtream account, obtained from BooXtream. Defaults to using
           settings.BOOXTREAM_API_USER
-          
-          
+
+
         ``timeout``
-        
+
         passed to requests
     """
     def __init__(self,
@@ -36,58 +35,60 @@ class BooXtream(object):
             apiuser = settings.BOOXTREAM_API_USER
         self.endpoint = 'https://service.booxtream.com/'
         self.postrequest = partial(requests.post, timeout=timeout, auth=(apiuser,apikey))
-        
+
 
     def platform(self,  epubfile=None, epub=True, kf8mobi=False,  **kwargs):
-        """ Make an API request to BooXtream 
+        """ Make an API request to BooXtream
         ``self.apikey``, ``epubfile`` and the supplied ``kwargs``.
         Attempts to deserialize the XML response and return the download link.
 
         Will raise ``BooXtreamError`` if BooXtream returns an exception
         code.
         """
-        url = self.endpoint + 'booxtream.xml' 
+        Boox = apps.get_model('booxtream', 'Boox')
+
+        url = self.endpoint + 'booxtream.xml'
         kwargs['epub'] =  '1' if epub else '0'
         kwargs['kf8mobi'] = '1' if kf8mobi else '0'
         if epubfile:
             if hasattr(epubfile,'name') and str(epubfile.name).endswith('.epub'):
                 files= {'epubfile': (str(epubfile.name),epubfile)}
             else:
-                # give it a random file name so that kindlegen doesn't choke 
-                # needed for in-memory (StringIO) epubs 
+                # give it a random file name so that kindlegen doesn't choke
+                # needed for in-memory (StringIO) epubs
                 files= {'epubfile': ('%012x.epub' % random.randrange(16**12),epubfile)}
         else:
-             files={}      
+             files={}
         if settings.LOCAL_TEST:
             # fake it, so you can test other functions without hitting booxtream
             boox = Boox.objects.create(
-                    download_link_epub='https://github.com/eshellman/42_ebook/blob/master/download/42.epub?raw=true&extra=download.booxtream.com/', 
-                    download_link_mobi='https://github.com/eshellman/42_ebook/blob/master/download/42.mobi?raw=true', 
-                    referenceid= kwargs.get('referenceid'),
-                    downloads_remaining= kwargs.get('downloadlimit'),
-                    expirydays=kwargs.get('expirydays'),
-                )
+                download_link_epub='https://github.com/eshellman/42_ebook/blob/master/download/42.epub?raw=true&extra=download.booxtream.com/',
+                download_link_mobi='https://github.com/eshellman/42_ebook/blob/master/download/42.mobi?raw=true',
+                referenceid= kwargs.get('referenceid'),
+                downloads_remaining= kwargs.get('downloadlimit'),
+                expirydays=kwargs.get('expirydays'),
+            )
             return boox
 
         resp = self.postrequest(url, data=kwargs, files=files)
         doc = ElementTree.fromstring(resp.content)
 
         # it turns out an Error can have an Error in it
-        errors = doc.findall('.//Response/Error') 
+        errors = doc.findall('.//Response/Error')
         if len(errors) > 0:
             raise BooXtreamError(errors)
         download_link_epub = doc.find('.//DownloadLink[@type="epub"]')
         if download_link_epub is not None:
-            download_link_epub = download_link_epub.text  
+            download_link_epub = download_link_epub.text
         download_link_mobi = doc.find('.//DownloadLink[@type="mobi"]')
         if download_link_mobi is not None:
-            download_link_mobi = download_link_mobi.text 
+            download_link_mobi = download_link_mobi.text
         boox = Boox.objects.create(
-                download_link_epub=download_link_epub, 
-                download_link_mobi=download_link_mobi, 
-                referenceid= kwargs.get('referenceid'),
-                downloads_remaining= kwargs.get('downloadlimit'),
-                expirydays=kwargs.get('expirydays'),
-            )
+            download_link_epub=download_link_epub,
+            download_link_mobi=download_link_mobi,
+            referenceid= kwargs.get('referenceid'),
+            downloads_remaining= kwargs.get('downloadlimit'),
+            expirydays=kwargs.get('expirydays'),
+        )
         return boox
 

--- a/core/apps.py
+++ b/core/apps.py
@@ -1,11 +1,10 @@
 from django.apps import AppConfig
 from django.db.models.signals import post_migrate
 
-from regluit.core.signals import create_notice_types
-
 class CoreConfig(AppConfig):
     name = 'regluit.core'
     verbose_name = ' core objects'
 
     def ready(self):
+        from regluit.core.signals import create_notice_types
         post_migrate.connect(create_notice_types, sender=self)

--- a/core/signals.py
+++ b/core/signals.py
@@ -101,7 +101,7 @@ def create_notice_types( **kwargs):
     notification.create_notice_type("purchase_notgot_gift", _("Your gift wasn't received."), _("The ebook you sent as a gift has not yet been redeemed."))
     notification.create_notice_type("donation", _("Your donation was processed."), _("Thank you, your generous donation has been processed."))
     
-signals.post_syncdb.connect(create_notice_types, sender=notification)
+signals.post_migrate.connect(create_notice_types, sender=notification)
 
 # define the notifications and tie them to corresponding signals
 

--- a/core/tests.py
+++ b/core/tests.py
@@ -193,7 +193,7 @@ class BookLoaderTests(TestCase):
         self.assertEqual(models.Work.objects.all().count(), before)
 
     def test_missing_isbn(self):
-        e = bookloader.add_by_isbn_from_google('0139391401')
+        e = bookloader.add_by_isbn_from_google('9781938616990') #unassigned in gluejar block
         self.assertEqual(e, None)
 
     def test_thingisbn_mock(self):

--- a/core/tests.py
+++ b/core/tests.py
@@ -5,9 +5,10 @@ import os
 from datetime import datetime, timedelta
 from decimal import Decimal as D
 from math import factorial
-from time import sleep, mktime
+import unittest
 from urlparse import parse_qs, urlparse
 from tempfile import NamedTemporaryFile
+from time import sleep, mktime
 
 from celery.task.sets import TaskSet
 import requests
@@ -25,7 +26,6 @@ from django.http import Http404
 from django.test import TestCase
 from django.test.client import Client
 from django.test.utils import override_settings
-from django.utils import unittest
 from django.utils.timezone import now
 
 from django_comments.models import Comment
@@ -163,7 +163,7 @@ class BookLoaderTests(TestCase):
         if not (mocking or settings.TEST_INTEGRATION):
             return
         edition = bookloader.add_by_isbn('9787104030126')
-        self.assertEqual(edition.work.language, 'zh-CN')
+        self.assertEqual(edition.work.language, u'zh-CN')
 
     def test_update_edition_mock(self):
         with requests_mock.Mocker(real_http=True) as m:

--- a/frontend/templates/campaign_list.html
+++ b/frontend/templates/campaign_list.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 
-{% load endless %}
+{% load el_pagination_tags %}
 {% load lang_utils %}
 {% load sass_tags %}
 

--- a/frontend/templates/cc_list.html
+++ b/frontend/templates/cc_list.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 
-{% load endless %}
+{% load el_pagination_tags %}
 {% load lang_utils %}
 {% load sass_tags %}
 

--- a/frontend/templates/faceted_list.html
+++ b/frontend/templates/faceted_list.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 
-{% load endless %}
+{% load el_pagination_tags %}
 {% load lang_utils %}
 {% load sass_tags %}
 

--- a/frontend/templates/libraryauth/library.html
+++ b/frontend/templates/libraryauth/library.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 
-{% load endless %}
+{% load el_pagination_tags %}
 {% load sass_tags %}
 {% load truncatechars %}
 

--- a/frontend/templates/supporter.html
+++ b/frontend/templates/supporter.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 
-{% load endless %}
+{% load el_pagination_tags %}
 {% load truncatechars %}
 {% load sass_tags %}
 

--- a/frontend/templates/unglued_list.html
+++ b/frontend/templates/unglued_list.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 
-{% load endless %}
+{% load el_pagination_tags %}
 {% load lang_utils %}
 {% load sass_tags %}
 

--- a/frontend/templates/work_list.html
+++ b/frontend/templates/work_list.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 
-{% load endless %}
+{% load el_pagination_tags %}
 {% load lang_utils %}
 {% load sass_tags %}
 

--- a/frontend/templatetags/lang_utils.py
+++ b/frontend/templatetags/lang_utils.py
@@ -1,12 +1,6 @@
-"""
-The truncatechars filter is part of Django dev, but we're on 1.3.1
-The following is the filter and its dependencies
-To use this filter, put "{% load truncatechars %}" at the beginning of your template, 
-then {{ myvariable|truncatechars:num }}
-"""
 import unicodedata
 
-from django.template.base import Library
+from django.template import Library
 from django.template.defaultfilters import stringfilter
 from django.utils.translation import get_language_info
 

--- a/frontend/templatetags/truncatechars.py
+++ b/frontend/templatetags/truncatechars.py
@@ -7,7 +7,7 @@ then {{ myvariable|truncatechars:num }}
 import unicodedata
 
 from django import template
-from django.template.base import Library
+from django.template import Library
 from django.template.defaultfilters import stringfilter
 from django.utils.encoding import force_unicode
 from django.utils.functional import allow_lazy, SimpleLazyObject

--- a/frontend/templatetags/urldecode.py
+++ b/frontend/templatetags/urldecode.py
@@ -3,7 +3,7 @@
 """
 from urllib import unquote
 
-from django.template.base import Library
+from django.template import Library
 from django.template.defaultfilters import stringfilter
 
 register = Library()

--- a/libraryauth/__init__.py
+++ b/libraryauth/__init__.py
@@ -1,1 +1,9 @@
-from . import signals
+from django.apps import AppConfig
+
+default_app_config = 'regluit.libraryauth.LibraryAuthConfig'
+
+class LibraryAuthConfig(AppConfig):
+    name = 'regluit.libraryauth'
+
+    def ready(self):
+        from . import signals

--- a/libraryauth/templatetags/libraryauthtags.py
+++ b/libraryauth/templatetags/libraryauthtags.py
@@ -1,6 +1,6 @@
 import unicodedata
 
-from django.template.base import Library
+from django.template import Library
 from .. import models
 
 register = Library()

--- a/payment/stripelib.py
+++ b/payment/stripelib.py
@@ -6,12 +6,15 @@ external library imports
 """
 import logging
 import json
-import re
-import stripe
 
 from datetime import datetime, timedelta
 from itertools import islice
 from pytz import utc
+import re
+import unittest
+from unittest import TestCase  
+  
+import stripe
 
 """
 django imports
@@ -73,12 +76,6 @@ def grouper(iterable, page_size):
 class StripelibError(baseprocessor.ProcessorError):
     pass
 
-try:
-    import unittest
-    from unittest import TestCase    
-except:
-    from django.test import TestCase
-    from django.utils import unittest
 
 # if customer.id doesn't exist, create one and then charge the customer
 # we probably should ask our users whether they are ok with our creating a customer id account -- or ask for credit

--- a/payment/tests.py
+++ b/payment/tests.py
@@ -20,11 +20,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
 from django.test import TestCase
-<<<<<<< HEAD
-=======
-from django.utils import unittest
 from django.utils.timezone import now
->>>>>>> Gluejar/master
 
 """
 regluit imports

--- a/payment/tests.py
+++ b/payment/tests.py
@@ -5,6 +5,7 @@ import logging
 import os
 import time
 import traceback
+import unittest
 
 from datetime import timedelta
 from decimal import Decimal as D
@@ -19,8 +20,11 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
 from django.test import TestCase
+<<<<<<< HEAD
+=======
 from django.utils import unittest
 from django.utils.timezone import now
+>>>>>>> Gluejar/master
 
 """
 regluit imports

--- a/payment/views.py
+++ b/payment/views.py
@@ -13,7 +13,7 @@ django imports
 """
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.contrib.sites.models import RequestSite
+from django.contrib.sites.requests import RequestSite
 from django.core.urlresolvers import reverse
 from django.http import (
     HttpResponse,

--- a/requirements_versioned.pip
+++ b/requirements_versioned.pip
@@ -1,9 +1,9 @@
-Django==1.8.14
+Django==1.9.13
 Fabric==1.6.0
 MySQL-python==1.2.5
 Pillow==3.4.2
 PyJWT==1.4.1
-PyPDF2==1.23
+PyPDF2==1.26
 PyGithub==1.15.0
 PyYAML==3.11
 amqp==1.4.9
@@ -19,29 +19,29 @@ certifi==2016.2.28
 django-celery==3.1.17
 django-ckeditor==4.5.1
 #django-email-change==0.2.3
-git+git://github.com/eshellman/django-email-change.git@1e71dd320504d56b1fc7d447ce4cffb550cedce7
+git+git://github.com/eshellman/django-email-change.git@57169bdef1c8a41d122e2bab2dcd8564b8fb231d
 django-compat==1.0.10
 django-contrib-comments==1.7.1
-django-endless-pagination==2.0
+django-el-pagination==3.2.4
 django-extensions==1.6.1
 django-jsonfield==1.0.0
 #django-kombu==0.9.4
 django-maintenancemode==0.11.2
 django-mptt==0.8.5
 #django-notification==0.2
-git+git://github.com/eshellman/django-notification.git@412c7a03a327195a1017c2be92c8e2caabc880b6
+git+git://github.com/eshellman/django-notification.git@a4620e893e2da220994e0189bf5d980bfbdcf0ad
 django-registration==2.1.2
 django-selectable==0.9.0
 django-smtp-ssl==1.0
 django-storages==1.4.1
 django-tastypie==0.13.3
-django-transmeta==0.7.3
+#django-transmeta==0.7.3 git+git://github.com/resulto/django-transmeta.git@ad4d7278ba330dcf8c8446f8ae9b2c769ae8684e
 fef-questionnaire==4.0.1
 #gitenberg.metadata==0.1.6
 git+https://github.com/gitenberg-dev/gitberg-build
 #git+ssh://git@github.com/gitenberg-dev/metadata.git@0.1.11
 github3.py==0.9.5
-html5lib==1.0b3
+html5lib==1.0.1
 httplib2==0.7.5
 isodate==0.5.1
 kombu==3.0.35
@@ -68,7 +68,7 @@ pytz==2016.6.1
 rdflib==4.2.0
 rdflib-jsonld==0.3
 redis==2.10.3
-reportlab==3.1.8
+reportlab==3.4.0
 requests==2.10.0
 requests-mock==1.2.0
 requests-oauthlib==0.6.2
@@ -82,7 +82,8 @@ virtualenv==1.4.9
 # virtualenv-clone==0.2.4 not sure why I have this in my env
 #virtualenvwrapper==3.6
 wsgiref==0.1.2
-xhtml2pdf==0.0.6
+xhtml2pdf==0.2.2
+webencodings==0.5.1
 #for urllib3 secure
 cffi==1.7.0
 cryptography==1.4

--- a/requirements_versioned.pip
+++ b/requirements_versioned.pip
@@ -1,4 +1,4 @@
-Django==1.9.13
+Django==1.8.14
 Fabric==1.6.0
 MySQL-python==1.2.5
 Pillow==3.4.2

--- a/requirements_versioned.pip
+++ b/requirements_versioned.pip
@@ -35,7 +35,8 @@ django-selectable==0.9.0
 django-smtp-ssl==1.0
 django-storages==1.4.1
 django-tastypie==0.13.3
-#django-transmeta==0.7.3 git+git://github.com/resulto/django-transmeta.git@ad4d7278ba330dcf8c8446f8ae9b2c769ae8684e
+#django-transmeta==0.7.3 
+git+git://github.com/resulto/django-transmeta.git@ad4d7278ba330dcf8c8446f8ae9b2c769ae8684e
 fef-questionnaire==4.0.1
 #gitenberg.metadata==0.1.6
 git+https://github.com/gitenberg-dev/gitberg-build

--- a/settings/common.py
+++ b/settings/common.py
@@ -165,7 +165,7 @@ INSTALLED_APPS = (
     'social.apps.django_app.default',
     'tastypie',
     'djcelery',
-    'endless_pagination',
+    'el_pagination',
     'selectable',
     'regluit.frontend.templatetags',
     'notification',

--- a/settings/dev.py
+++ b/settings/dev.py
@@ -29,7 +29,9 @@ DATABASES = {
         'PASSWORD': '',
         'HOST': '',
         'PORT': '',
-        'TEST_CHARSET': 'utf8',
+        'TEST': {
+            'CHARSET': 'utf8',
+        }
     }
 }
 

--- a/settings/jenkins.py
+++ b/settings/jenkins.py
@@ -20,7 +20,9 @@ DATABASES = {
         'PASSWORD': 'regluit',
         'HOST': '',
         'PORT': '',
-        'TEST_CHARSET': 'utf8',
+        'TEST': {
+            'CHARSET': 'utf8',
+        }
     }
 }
 

--- a/settings/just.py
+++ b/settings/just.py
@@ -22,7 +22,9 @@ DATABASES = {
         'PASSWORD': DATABASE_PASSWORD,
         'HOST': DATABASE_HOST,
         'PORT': '',
-        'TEST_CHARSET': 'utf8'
+        'TEST': {
+            'CHARSET': 'utf8',
+        }
     }
 }
 

--- a/settings/please.py
+++ b/settings/please.py
@@ -21,7 +21,9 @@ DATABASES = {
         'PASSWORD': DATABASE_PASSWORD,
         'HOST': DATABASE_HOST,
         'PORT': '',
-        'TEST_CHARSET': 'utf8',
+        'TEST': {
+            'CHARSET': 'utf8',
+        }
     }
 }
 

--- a/settings/prod.py
+++ b/settings/prod.py
@@ -23,7 +23,9 @@ DATABASES = {
         'PASSWORD': DATABASE_PASSWORD,
         'HOST': DATABASE_HOST,
         'PORT': '',
-        'TEST_CHARSET': 'utf8',
+        'TEST': {
+            'CHARSET': 'utf8',
+        }
     }
 }
 


### PR DESCRIPTION
On path to django 1.11, I've made changes so our codebase works in django 1.9. all of the changes needed were from code deprecated in 1.7, so everything also works in djang 1.8.

Since 1.9 is already EOL, we won't change until we have everything at 1.11, but putting these changes into production will help us find any problems before the big change.