### PR TITLE
switch to direct auth urls for reset password

### DIFF
--- a/frontend/templates/registration/password_reset_email.html
+++ b/frontend/templates/registration/password_reset_email.html
@@ -7,7 +7,7 @@ wish to reset your password, please ignore this message.
 To reset your password, please click the following link, or copy and paste it
 into your web browser:
 
-{{ protocol }}://{{ domain }}{% url 'auth_password_reset_confirm' uid token %}
+{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uid token %}
 
 Your username, in case you've forgotten: {{ user.username }}
 

--- a/frontend/templates/registration/password_reset_email.txt
+++ b/frontend/templates/registration/password_reset_email.txt
@@ -7,7 +7,7 @@ wish to reset your password, please ignore this message.
 To reset your password, please click the following link, or copy and paste it
 into your web browser:
 
-{{ protocol }}://{{ domain }}{% url 'auth_password_reset_confirm' uid token %}
+{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uid token %}
 
 Your username, in case you've forgotten: {{ user.username }}
 

--- a/libraryauth/urls.py
+++ b/libraryauth/urls.py
@@ -67,11 +67,11 @@ urlpatterns = [
     )),
     url(r'^accounts/password/change/$',
         login_required(views.social_aware_password_change),
-        {'post_change_redirect': reverse_lazy('auth_password_change_done')},
+        {'post_change_redirect': reverse_lazy('password_change_done')},
         name='libraryauth_password_change'),
     url(r'^password/reset/$',
         password_reset,
-        {'post_reset_redirect': reverse_lazy('auth_password_reset_done'),
+        {'post_reset_redirect': reverse_lazy('password_reset_done'),
         'password_reset_form': forms.SocialAwarePasswordResetForm},
         name='libraryauth_password_reset'),
 


### PR DESCRIPTION
in dj111, a self-redirect was breaking the django-registration url shims, causing a bad success url. (404)
so change urls to go direct.