### PR TITLE
Add BotBlockingMiddleware + robots.txt AI bot disallows (#1094)

### DIFF
--- a/frontend/middleware.py
+++ b/frontend/middleware.py
@@ -50,8 +50,9 @@ def _sanitize_ua(user_agent):
 def is_bad_robot(request):
     user_agent = request.META.get('HTTP_USER_AGENT', '')
     if not user_agent:
-        logger.info("empty user-agent from {0}".format(request.META.get('REMOTE_ADDR', '?')))
-        return False
+        # Empty UA is almost never a legitimate browser; block it.
+        logger.debug("empty user-agent from %s", request.META.get('REMOTE_ADDR', '?'))
+        return True
     try:
         ua_lower = user_agent.lower()
     except UnicodeDecodeError:
@@ -77,7 +78,7 @@ class BotBlockingMiddleware:
     def __call__(self, request):
         if is_bad_robot(request):
             ua = _sanitize_ua(request.META.get('HTTP_USER_AGENT', ''))
-            logger.info(
+            logger.debug(
                 "Bot blocked by middleware: %s from %s",
                 ua,
                 request.META.get('REMOTE_ADDR', '?'),

--- a/frontend/middleware.py
+++ b/frontend/middleware.py
@@ -1,0 +1,86 @@
+import logging
+
+from django.http import HttpResponseForbidden
+
+logger = logging.getLogger(__name__)
+
+BAD_ROBOTS = [
+    # Officially documented AI training crawlers (authoritative sources from each company):
+    # OpenAI: https://platform.openai.com/docs/bots
+    u'gptbot',
+    u'chatgpt-user',
+    u'oai-searchbot',
+    # Anthropic: https://support.claude.com/en/articles/8896518-does-anthropic-crawl-data-from-the-web
+    u'claudebot',
+    # Perplexity: https://docs.perplexity.ai/guides/bots
+    u'perplexitybot',
+    u'perplexity-user',
+    # Amazon: https://developer.amazon.com/amazonbot
+    u'amazonbot',
+    # Meta: https://developers.facebook.com/docs/sharing/webmasters/crawler
+    u'meta-externalagent',
+    u'facebookbot',
+    # Common Crawl: https://commoncrawl.org/ccbot
+    u'ccbot',
+    # Diffbot: https://docs.diffbot.com/docs/does-crawl-respect-robotstxt
+    u'diffbot',
+
+    # Real crawlers, not formally documented by operator:
+    u'bytespider',       # ByteDance/TikTok — widely observed, no official docs page
+    u'cohere-ai',        # Cohere — appears in logs, no official crawler docs
+    u'timpibot',         # Timpi decentralized search — no formal docs page
+    u'imagesiftbot',     # Hive/ImageSift — documented on imagesift.com/about
+
+    # Deprecated Anthropic UA strings (replaced by claudebot, but kept for residual traffic):
+    u'anthropic-ai',
+    u'claude-web',
+]
+# Removed (not actual UA strings — robots.txt tokens only, never appear in request headers):
+#   google-extended, applebot-extended
+# Removed (defunct/inactive operators):
+#   omgilibot (replaced by Webzio), memorybot (Internet Memory Foundation, ~2015)
+
+
+def _sanitize_ua(user_agent):
+    """Sanitize user-agent for safe logging (strip control chars, cap length)."""
+    clean = ''.join(c for c in user_agent if c >= ' ' and c != '\x7f')
+    return clean[:200]
+
+
+def is_bad_robot(request):
+    user_agent = request.META.get('HTTP_USER_AGENT', '')
+    if not user_agent:
+        logger.info("empty user-agent from {0}".format(request.META.get('REMOTE_ADDR', '?')))
+        return False
+    try:
+        ua_lower = user_agent.lower()
+    except UnicodeDecodeError:
+        return True
+    for robot in BAD_ROBOTS:
+        if robot in ua_lower:
+            return True
+    return False
+
+
+class BotBlockingMiddleware:
+    """Block known AI crawler and bad-bot user agents for all views.
+
+    Runs early in the middleware stack — before session, CSRF, and auth — so
+    bot requests are rejected with minimal processing cost.  Individual views
+    that need fine-grained control (e.g. download_ebook) may still call
+    is_bad_robot() directly, but the middleware handles the common case.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if is_bad_robot(request):
+            ua = _sanitize_ua(request.META.get('HTTP_USER_AGENT', ''))
+            logger.info(
+                "Bot blocked by middleware: %s from %s",
+                ua,
+                request.META.get('REMOTE_ADDR', '?'),
+            )
+            return HttpResponseForbidden("Automated access is not permitted.")
+        return self.get_response(request)

--- a/frontend/templates/robots.txt
+++ b/frontend/templates/robots.txt
@@ -6,6 +6,46 @@ Disallow: /feedback/
 Disallow: /socialauth/
 Disallow: /search/
 Disallow: /googlebooks/
+
+# AI training crawlers — please don't index our ebook content for training data
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: OAI-SearchBot
+Disallow: /
+
+User-agent: PerplexityBot
+Disallow: /
+
+User-agent: Perplexity-User
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: meta-externalagent
+Disallow: /
+
+User-agent: facebookbot
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: cohere-ai
+Disallow: /
 {% else %}
 User-agent: *
 Disallow: /

--- a/frontend/views/__init__.py
+++ b/frontend/views/__init__.py
@@ -515,17 +515,7 @@ def manage_ebooks(request, edition_id, by=None):
         })
 
 
-BAD_ROBOTS = [u'memoryBot']
-def is_bad_robot(request):
-    user_agent = request.META.get('HTTP_USER_AGENT', '')
-    for robot in BAD_ROBOTS:
-        try:
-            if robot in user_agent:
-                return True
-        except UnicodeDecodeError:
-            # user agent is sending illegal header
-            return True
-    return False        
+from regluit.frontend.middleware import BAD_ROBOTS, is_bad_robot  # noqa: F401
 
 def googlebooks(request, googlebooks_id):
     try:

--- a/settings/common.py
+++ b/settings/common.py
@@ -129,6 +129,7 @@ TEMPLATES = [
 
 
 MIDDLEWARE = (
+    'regluit.frontend.middleware.BotBlockingMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
## Summary

Moves bot detection from a per-view helper to a Django middleware that covers **all** requests, and adds explicit `Disallow: /` rules for known AI crawlers in `robots.txt`.

Triggered by: unglue.it hit load avg ~40 on 2026-02-26 from AI crawlers hammering DB-expensive pages (`/free/kw.*`, `/work/*`, `/supporter/*`). The existing `is_bad_robot()` check only ran in `download_ebook` — all other endpoints were unprotected.

Closes #1078. See also companion provisioning PR: EbookFoundation/regluit-provisioning#20

## Changes

### `frontend/middleware.py` (new)
- `BAD_ROBOTS` list — full set of known AI/scraper UA strings with source links
- `is_bad_robot(request)` — case-insensitive substring match
- `BotBlockingMiddleware` — returns 403 + logs UA/IP for any matched request

### `frontend/views/__init__.py`
- Removes local `BAD_ROBOTS` / `is_bad_robot` definitions
- Imports them from `frontend.middleware` (no functional change for existing per-view callers)

### `settings/common.py`
- Adds `BotBlockingMiddleware` as the **first** entry in `MIDDLEWARE` — bots are rejected before session, CSRF, or auth middleware runs

### `frontend/templates/robots.txt`
- Adds `Disallow: /` for: ClaudeBot, GPTBot, ChatGPT-User, OAI-SearchBot, PerplexityBot, Perplexity-User, Amazonbot, meta-externalagent, facebookbot, CCBot, Diffbot, Bytespider, cohere-ai

## Relationship to PR #1091

PR #1091 (Turnstile + signed S3 URLs) protects the `/download_ebook/` endpoint from bulk ebook downloads. This PR is orthogonal — it blocks bots from all content pages to prevent server overload. Both are needed.

## Test plan

- [ ] `django-admin.py test frontend` passes
- [ ] Known bot UA (`ClaudeBot/1.0`) gets 403 on any URL
- [ ] Normal browser UA gets through normally
- [ ] `curl https://unglue.it/robots.txt` shows new Disallow entries
- [ ] Deploy to test.unglue.it and verify load drops