### PR TITLE
Fix TypeError in load_doab when run without --max argument

### DIFF
--- a/core/loaders/doab.py
+++ b/core/loaders/doab.py
@@ -516,7 +516,7 @@ def load_doab_oai(from_date, until_date, limit=100):
                     new_doabs += 1
                 title = e.title if e else None
                 logger.info(u'updated:\t%s\t%s', doab, title)
-            if num_doabs >= limit:
+            if limit is not None and num_doabs >= limit:
                 break
     except NoRecordsMatchError:
         pass


### PR DESCRIPTION
## Problem

`load_doab` crashes on every unattended run (no `--max` flag) with:

```
TypeError: '>=' not supported between instances of 'int' and 'NoneType'
```

`--max` defaults to `None`, gets passed to `load_doab_oai(limit=max)`, then hits `num_doabs >= limit` at `doab.py:519`. Python 3 doesn't allow `int >= None`.

This was confirmed by running the command on prod (2026-03-03) — it printed `starting at date:None until:None, max: None` then immediately crashed.

## Fix

```python
# before
if num_doabs >= limit:

# after  
if limit is not None and num_doabs >= limit:
```

`limit=None` now means no cap, which was the original intent.

## Context

Identified in investigation of #1096 (OAI harvester not picking up new DOAB books). Flagged as a high-severity finding by Codex review.

Closes #1096 (partially — scheduler and null-edition issues tracked separately).