### PR TITLE
Handle DOAB OAI HTTP 429 rate-limit gracefully

### DIFF
--- a/core/loaders/doab.py
+++ b/core/loaders/doab.py
@@ -3,6 +3,7 @@
 import datetime
 import logging
 import re
+import urllib.error
 
 import requests
 
@@ -520,5 +521,15 @@ def load_doab_oai(from_date, until_date, limit=100):
                 break
     except NoRecordsMatchError:
         pass
+    except urllib.error.HTTPError as e:
+        if e.code == 429:
+            retry_after = e.headers.get('Retry-After', 'unknown')
+            logger.error(
+                'DOAB OAI rate-limited (HTTP 429). '
+                'Retry-After: %s seconds. Harvest stopped after %s records.',
+                retry_after, num_doabs
+            )
+        else:
+            raise
     return num_doabs, new_doabs, lasttime
     


### PR DESCRIPTION
## Summary

- Adds `import urllib.error` to `doab.py`
- Catches `urllib.error.HTTPError` alongside `NoRecordsMatchError` in `load_doab_oai()`
- On 429: logs the `Retry-After` value and record count at point of cutoff, then returns normally
- On any other HTTP error: re-raises as before

## Why

DOAB's OAI endpoint rate-limits by IP and responds with:
```
HTTP/2 429
retry-after: 86400
```
> *"We've detected an unusually high number of requests from your IP address, and access has been temporarily restricted for 24 hours."*

Previously, `pyoai` raised `urllib.error.HTTPError` which propagated unhandled through `load_doab_oai()`, crashing the management command before it could print the `loaded N records` summary line. The `Retry-After` header was silently discarded. The operator saw only a blank entry in `load_doab.txt` — indistinguishable from the TypeError crash fixed in #1097.

After this fix, the app log will show:
```
ERROR DOAB OAI rate-limited (HTTP 429). Retry-After: 86400 seconds. Harvest stopped after 8 records.
```
and the management command will print its normal summary with however many records were loaded before the cutoff.

## Test plan

- [ ] Deploy to test.unglue.it (currently blocked for 24h due to rate limit — retry tomorrow)
- [ ] Trigger a 429 by running back-to-back harvests; confirm app log shows the error with Retry-After value
- [ ] Confirm `loaded N records` still prints in management command output
- [ ] Confirm non-429 HTTPErrors still propagate (raise)

## Related

- Closes #1100
- Part of #1096 (DOAB harvester investigation)
- Companion to #1097 (TypeError fix) and #1099 (timeout fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)