### PR TITLE
DOAB harvest reliability: per-record exception isolation and 429 in get_streamdata

### DIFF
--- a/core/loaders/doab.py
+++ b/core/loaders/doab.py
@@ -508,7 +508,11 @@ def load_doab_oai(from_date, until_date, limit=100):
             doab = getdoab(ident)
             if doab:
                 num_doabs += 1
-                e = add_by_doab(doab, record=record)
+                try:
+                    e = add_by_doab(doab, record=record)
+                except Exception as ex:
+                    logger.exception('unexpected error processing doab #%s: %s', doab, ex)
+                    continue
                 if not e:
                     logger.error('null edition for doab #%s', doab)
                     continue

--- a/core/loaders/doab_utils.py
+++ b/core/loaders/doab_utils.py
@@ -128,6 +128,10 @@ def get_streamdata(handle):
     url = STREAM_QUERY.format(handle)
     try:
         response = requests.get(url, headers={"User-Agent": settings.USER_AGENT}, timeout=(5, 60))
+        if response.status_code == 429:
+            retry_after = response.headers.get('Retry-After', 'unknown')
+            logger.error('DOAB bitstream API rate-limited (HTTP 429) for %s. Retry-After: %s', handle, retry_after)
+            return None
         items = response.json()
         if items:
             for stream in items[0]['bitstreams']:


### PR DESCRIPTION
## Summary

Two reliability improvements to prevent a single failure from masking all subsequent failures.

### 1. Per-record exception isolation in `load_doab_oai()`

`add_by_doab()` was called with no `try/except`. Any unhandled exception — DB constraint violation, unexpected metadata shape, network error — would abort the entire remaining harvest window silently. The record count and `lasttime` would reflect only the records processed before the failure, with no indication of what went wrong.

Now wraps each `add_by_doab()` call in `try/except Exception`, logs the DOAB ID and error, and continues to the next record.

### 2. Explicit 429 handling in `get_streamdata()`

Previously, when the DOAB bitstream REST API returned 429, `response.json()` raised `ValueError` (DOAB returns HTML on rate-limit), which was caught and logged only as `"decoder error"` — masking the real cause and making it hard to diagnose rate-limiting of cover fetches.

Now checks `response.status_code == 429` before calling `.json()` and logs a clear error with the `Retry-After` value.

## Note on management command visibility

Surfacing partial 429 harvests in the management command's stdout output (so `loaded N records` is marked as incomplete) requires coordination with PR #1101, which changes `load_doab_oai()`'s exception handling. That improvement is tracked in #1105 and will be addressed as a follow-up once #1101 is merged.

## Test plan

- [ ] Introduce a synthetic exception in `add_by_doab()` for one record; confirm harvest continues and logs the error
- [ ] Confirm covers still load for records that don't trigger errors
- [ ] Confirm `get_streamdata` logs a clear 429 message (not "decoder error") when rate-limited

## Related

- Closes #1105 (partially — management command visibility pending #1101)
- Part of #1096 (DOAB harvester investigation)
- Companion to PR #1101 (429 handling in OAI loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)