### PR TITLE
Add data-appearance=interaction-only to all Turnstile widgets (#1092)

### DIFF
--- a/frontend/templates/add_your_books.html
+++ b/frontend/templates/add_your_books.html
@@ -4,7 +4,7 @@
 	<p id="add_your_books"><b>Claiming a work</b></p>
 	<p>If your book is indexed in Google books, we can add it to our database automagically. Click on the result list to add your book to our database.</p>
 	<form action="{% url 'search' %}" method="get">
-        <div class="cf-turnstile" data-sitekey="{% cf_site %}"  data-callback="enableSubmit"></div>
+        <div class="cf-turnstile" data-sitekey="{% cf_site %}" data-appearance="interaction-only" data-callback="enableSubmit"></div>
         <div class="inputalign">
             <input type="text" id="nowatermark" size="25" class="inputbox" name="q" value="{{ q }}" required>
             <input type="submit" class="button" id="search-button" disabled>

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -68,7 +68,7 @@
                     </div>
                     </div>
                 </div>
-                <div class="cf-turnstile" data-sitekey="{% cf_site %}"  data-callback="enableSubmit"></div>
+                <div class="cf-turnstile" data-sitekey="{% cf_site %}" data-appearance="interaction-only" data-callback="enableSubmit"></div>
             </form>
             {% endif %}
             {% endblock %}

--- a/frontend/templates/registration/welcome.html
+++ b/frontend/templates/registration/welcome.html
@@ -8,7 +8,7 @@
 <p>Welcome, {{user.username}}!</p><p id="link-to-next"></p>
     <label>Search and add free-licenced books! </label>
     <form action="{% url 'search' %}" method="get">
-        <div class="cf-turnstile" data-sitekey="{% cf_site %}"  data-callback="enableSubmit"></div>
+        <div class="cf-turnstile" data-sitekey="{% cf_site %}" data-appearance="interaction-only" data-callback="enableSubmit"></div>
         <div class="inputalign">
         <input type="text" id="nowatermark" size="25" class="inputbox" name="q" value="{{ q }}" required>
         <input type="submit" class="button" id="search-button" disabled>

--- a/frontend/templates/supporter.html
+++ b/frontend/templates/supporter.html
@@ -260,7 +260,7 @@ function highlightTarget(targetdiv) {
                                 <div id="js-search">
                                     <label>Search and add free-licenced books! </label>
                                     <form action="{% url 'search' %}" method="get">
-                                        <div class="cf-turnstile" data-sitekey="{% cf_site %}"  data-callback="enableSubmit2"></div>
+                                        <div class="cf-turnstile" data-sitekey="{% cf_site %}" data-appearance="interaction-only" data-callback="enableSubmit2"></div>
                                         <div class="inputalign">
                                         <input type="text" id="nowatermark" size="25" class="inputbox" name="q" value="{{ q }}" required>
                                         <input type="submit" class="button" id="search-button-2" disabled>


### PR DESCRIPTION
## Summary
Adds `data-appearance="interaction-only"` to all 4 Turnstile widget instances:
- `base.html` (search bar)
- `registration/welcome.html`
- `supporter.html`
- `add_your_books.html`

Makes the CAPTCHA invisible unless user interaction is needed. Review caught that the initial fix only covered 1 of 4 templates.

Fixes #1092