### PR TITLE
Remove Booxtream B2U watermarking dead code (#1093)

### DIFF
--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -63,7 +63,7 @@ from regluit.core.parameters import (
     ACQ_CHOICES,
     GOOD_PROVIDERS,
 )
-from regluit.core.epub import personalize, ungluify, ask_epub
+from regluit.core.epub import personalize, ask_epub
 from regluit.core.pdf import ask_pdf, pdf_append
 from regluit.core.signals import (
     successful_campaign,
@@ -545,7 +545,7 @@ class Campaign(models.Model):
                 self.save()
                 action = CampaignAction(campaign=self, type='succeeded', comment=self.current_total)
                 action.save()
-                self.watermark_success()
+                # B2U watermark_success() removed (#1093); entire B2U branch is dead code (#1081)
                 if send_notice:
                     successful_campaign.send(sender=None, campaign=self)
 
@@ -974,54 +974,6 @@ class Campaign(models.Model):
             else:
                 ebf.ebook.activate()
                 format_versions.append(format_version)
-
-    def make_unglued_ebf(self, format, watermarked):
-        r = urlopen(watermarked.download_link(format))
-        ebf = EbookFile.objects.create(edition=self.work.preferred_edition, format=format)
-        ebf.file.save(path_for_file(ebf, None), ContentFile(r.read()))
-        ebf.file.close()
-        ebf.save()
-        ebook = Ebook.objects.create(
-            edition=self.work.preferred_edition,
-            format=format,
-            rights=self.license,
-            provider="Unglue.it",
-            url=settings.BASE_URL_SECURE + reverse('download_campaign', args=[self.work_id, format]),
-            version_label='unglued',
-            filesize=ebf.file.size,
-        )
-        old_ebooks = Ebook.objects.exclude(pk=ebook.pk).filter(
-            edition=self.work.preferred_edition,
-            format=format,
-            rights=self.license,
-            provider="Unglue.it",
-        )
-        for old_ebook in old_ebooks:
-            old_ebook.deactivate()
-        return ebook.pk
-
-
-    def watermark_success(self):
-        if self.status == 'SUCCESSFUL' and self.type == BUY2UNGLUE:
-            params = {
-                'customeremailaddress': self.license,
-                'customername': 'The Public',
-                'languagecode':'1033',
-                'expirydays': 1,
-                'downloadlimit': 7,
-                'exlibris':0,
-                'chapterfooter':0,
-                'disclaimer':0,
-                'referenceid': '%s:%s:%s' % (self.work_id, self.id, self.license),
-                'kf8mobi': True,
-                'epub': True,
-            }
-            ungluified = ungluify(self.work.epubfiles()[0].file, self)
-            ungluified.file_obj.seek(0)
-            watermarked = watermarker.platform(epubfile=ungluified.file_obj, **params)
-            self.make_unglued_ebf('epub', watermarked)
-            return True
-        return False
 
     def is_pledge(self):
         return  self.type == REWARDS

--- a/core/signals.py
+++ b/core/signals.py
@@ -31,9 +31,8 @@ from registration.signals import user_activated
 regluit imports
 """
 from regluit.payment.signals import transaction_charged, transaction_failed, pledge_modified, pledge_created
-from regluit.core.parameters import REWARDS, BUY2UNGLUE, THANKS, LIBRARY, RESERVE, THANKED
-from regluit.libraryauth.models import Library, LibraryUser
-from regluit.utils.localdatetime import date_today
+from regluit.core.parameters import REWARDS, THANKS, THANKED
+from regluit.libraryauth.models import LibraryUser
 
 logger = logging.getLogger(__name__)
 
@@ -175,36 +174,6 @@ def handle_transaction_charged(sender,transaction=None, **kwargs):
             send_mail_task.delay('unglue.it donation confirmation', message, 'notices@gluejar.com', [transaction.receipt])
     elif transaction.campaign.type is REWARDS:
         notification.send([transaction.user], "pledge_charged", context, True)
-    elif transaction.campaign.type is BUY2UNGLUE:
-        # provision the book
-        Acq = apps.get_model('core', 'Acq')
-        if transaction.offer.license == LIBRARY:
-            library = Library.objects.get(id=transaction.extra['library_id'])
-            new_acq = Acq.objects.create(user=library.user,work=transaction.campaign.work,license= LIBRARY)
-            if transaction.user_id != library.user_id:  # don't put it on reserve if purchased by the library
-                reserve_acq =  Acq.objects.create(user=transaction.user,work=transaction.campaign.work,license= RESERVE, lib_acq = new_acq)
-                reserve_acq.expire_in(datetime.timedelta(hours=2))
-            copies = int(transaction.extra.get('copies',1))
-            while copies > 1:
-                Acq.objects.create(user=library.user,work=transaction.campaign.work,license= LIBRARY)
-                copies -= 1
-        else:
-            if transaction.extra.get('give_to', False):
-                # it's a gift!
-                Gift = apps.get_model('core', 'Gift')
-                giftee = Gift.giftee(transaction.extra['give_to'], str(transaction.id))
-                new_acq = Acq.objects.create(user=giftee, work=transaction.campaign.work, license= transaction.offer.license)
-                gift = Gift.objects.create(acq=new_acq, message=transaction.extra.get('give_message',''), giver=transaction.user , to = transaction.extra['give_to'])
-                context['gift'] = gift
-                notification.send([giftee], "purchase_gift", context, True)
-            else:
-                new_acq = Acq.objects.create(user=transaction.user,work=transaction.campaign.work,license= transaction.offer.license)
-        transaction.campaign.update_left()
-        notification.send([transaction.user], "purchase_complete", context, True)
-        from regluit.core.tasks import watermark_acq
-        watermark_acq.delay(new_acq.id)
-        if transaction.campaign.cc_date < date_today() :
-            transaction.campaign.update_status(send_notice=True)
     elif transaction.campaign.type is THANKS:
         if transaction.user:
             Acq = apps.get_model('core', 'Acq')

--- a/frontend/templates/edition_uploads.html
+++ b/frontend/templates/edition_uploads.html
@@ -39,20 +39,6 @@
 {% endif %}
 {% if uploaded %}
     <h2> Your file was successfully loaded. </h2>
-    {% ifequal edition.work.last_campaign.type 2 %}
-        {% if watermarked %}
-            <p> Reference id: <b>{{watermarked.referenceid}}</b></p>
-            <ul> 
-            <li><a href="{{watermarked.download_link_epub}}">Processed epub for testing</a></li>
-            </ul>
-        {% else %}{% if upload_error %}
-            <p>
-            <span class="yikes">Unfortunately, your file failed testing.</span>
-            The error(s) were: <pre>
-            {{ upload_error }}</pre>
-            </p>
-        {% endif %}{% endif %}
-    {% endifequal %}
     {% ifequal edition.work.last_campaign.type 3 %}
         {% if upload_error %}
             <p><span class="yikes">Unfortunately, your file failed testing.</span>
@@ -63,9 +49,6 @@
 {% endif %}
 {{ upload_error }}
 <h2>Upload Ebook files</h2>
-{% ifequal edition.work.last_campaign.type 2 %}
-<p>At this time, we accept only EPUB files for "Buy to Unglue" campaigns. 
-{% endifequal %}
 {% ifequal edition.work.last_campaign.type 3 %}
 <p>You can upload PDF, EPUB and MOBI files for "Thanks for Ungluing" campaigns. 
 {% endifequal %}

--- a/frontend/templates/manage_campaign.html
+++ b/frontend/templates/manage_campaign.html
@@ -275,11 +275,6 @@ Please fix the following before launching your campaign:
 	<!--{{ form.deadline.errors }}--><!--{{ form.cc_date_initial.errors }}-->
 	{% endif %}
 {% endif %}
-{% if campaign.type == 2 %}
-    <h3>Personalization</h3>
-    <p>If you do not want Unglue.it to use digital watermarking techniques to encode a transaction number into the ebook files, uncheck this box. Either way, ebook files will be personalized; the difference is whether  personalization is easy or hard to remove.</p>
-    <div class="std_form">Use watermarking: {{ form.do_watermark }}</div>
-{% endif %}{{ form.do_watermark.errors }}
 
 
 	<h3>Your Pitch</h3>


### PR DESCRIPTION
## Summary
Removes BUY2UNGLUE (campaign type=2) watermarking code:
- `Campaign.watermark_success()` and `Campaign.make_unglued_ebf()` from models
- B2U branch from `handle_transaction_charged` signal
- B2U-only template blocks in `manage_campaign.html` and `edition_uploads.html`

**Library lending Booxtream integration is fully preserved** — `Acq.get_watermarked()`, `Acq.borrow()`, `watermark_acq` task, and all related code untouched.

Reviewed by isolated Claude agent + Codex. Codex flagged `do_watermark` form field — confirmed it's used by library lending and correctly preserved.

Closes #1093