### PR TITLE
Treat /free/all/... as a base-facet alias (#1117)

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -69,6 +69,10 @@ class FeedTests(TestCase):
         r = self.client.get('/api/opds/?work=%s' % self.test_work_id)
         self.assertEqual(r.status_code, 200)
 
+    def test_opds_all_keyword_alias_works(self):
+        r = self.client.get('/api/opds/all/kw.Fiction/')
+        self.assertEqual(r.status_code, 200)
+
     def test_nix(self):
         r = self.client.get('/api/onix/by/')
         self.assertEqual(r.status_code, 200)
@@ -77,6 +81,10 @@ class FeedTests(TestCase):
         r = self.client.get('/api/onix/epub/?max=10')
         self.assertEqual(r.status_code, 200)
         r = self.client.get('/api/onix/?work=%s' % self.test_work_id)
+        self.assertEqual(r.status_code, 200)
+
+    def test_onix_all_keyword_alias_works(self):
+        r = self.client.get('/api/onix/all/kw.Fiction/')
         self.assertEqual(r.status_code, 200)
 
 class AllowedRepoTests(TestCase):

--- a/core/facets.py
+++ b/core/facets.py
@@ -393,10 +393,13 @@ def get_all_facets(group='all'):
 
 def get_facet_object(facet_path):
     facets = facet_path.replace('//','/').strip('/').split('/')
+    if len(facets) > 1:
+        # `all` is a compatibility alias for the base facet, not a real facet.
+        facets = [facet for facet in facets if facet and facet != 'all']
     facet_object = None
     for facet in facets[:MAX_FACETS]:
         facet_object = get_facet(facet)(facet_object)
-    return facet_object
+    return facet_object if facet_object else BaseFacet(None)
 
 def get_order_by(order_by_key):
     # return the args to use as arguments for order_by

--- a/frontend/tests.py
+++ b/frontend/tests.py
@@ -152,6 +152,27 @@ class PageTests(TestCase):
         r = anon_client.get("/free/epub/gfdl/")
         self.assertEqual(r.status_code, 200)
 
+class AllFacetAliasTests(TestCase):
+    fixtures = ['initial_data.json', 'neuromancer.json']
+
+    def test_all_keyword_alias_matches_keyword_path(self):
+        plain = self.client.get("/free/kw.Fiction/?order_by=newest")
+        alias = self.client.get("/free/all/kw.Fiction/?order_by=newest")
+        self.assertEqual(plain.status_code, 200)
+        self.assertEqual(alias.status_code, 200)
+        self.assertContains(plain, "Show me only")
+        self.assertContains(alias, "Show me only")
+        self.assertEqual(plain.context['path'], 'kw.Fiction')
+        self.assertEqual(alias.context['path'], 'kw.Fiction')
+
+    def test_all_non_keyword_alias_matches_compound_path(self):
+        plain = self.client.get("/free/epub/doab/?order_by=newest")
+        alias = self.client.get("/free/all/epub/doab/?order_by=newest")
+        self.assertEqual(plain.status_code, 200)
+        self.assertEqual(alias.status_code, 200)
+        self.assertEqual(plain.context['path'], 'epub/doab')
+        self.assertEqual(alias.context['path'], 'epub/doab')
+
 class GoogleBooksTest(TestCase):
     fixtures = ['initial_data.json', 'neuromancer.json']
     def test_googlebooks_id(self):
@@ -159,5 +180,4 @@ class GoogleBooksTest(TestCase):
         self.assertEqual(r.status_code, 302)
         work_url = r['location']
         self.assertTrue(re.match(r'.*/work/\d+/$', work_url))
-
 


### PR DESCRIPTION
Fixes #1117

## Summary

Treats `all` as a compatibility alias for the base facet during path parsing instead of counting it as a real facet when other facets are present.

This makes URLs like `/free/all/kw.Nonfiction/` behave the same as `/free/kw.Nonfiction/` instead of losing refine options because `all` consumed one of the facet slots.

## Changes

- normalize `all` away when additional facet segments are present
- preserve `/free/all/` and empty/base facet behavior
- add web regression tests for `all`-prefixed keyword and non-keyword paths
- add OPDS and ONIX regression tests for `all`-prefixed keyword paths

## Notes

I did not run the Django test suite locally because this workspace does not have the repo's pinned Python `3.9.11` installed.