### PR TITLE
Add Docker Compose development setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+*.pyc
+__pycache__
+*.egg-info
+logs/
+*.log
+*.db
+*.ipynb
+.ipynb_checkpoints/
+settings/keys/
+settings/me.py
+.env
+src/
+vagrant/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+FROM python:3.8-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV DJANGO_SETTINGS_MODULE=regluit.settings.docker
+
+WORKDIR /opt/regluit
+
+# System deps for mysqlclient, Pillow, lxml, cairocffi, libsass
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    g++ \
+    git \
+    default-libmysqlclient-dev \
+    pkg-config \
+    libjpeg-dev \
+    libxml2-dev \
+    libxslt1-dev \
+    libcairo2-dev \
+    libfreetype6-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+# Install git-based editable deps to /usr/local/src (not the workdir which gets volume-mounted)
+RUN pip install --no-cache-dir --src /usr/local/src -r requirements.txt && \
+    pip install --no-cache-dir libsass
+
+COPY . .
+
+# Add project parent to Python path so `import regluit` resolves
+ENV PYTHONPATH=/opt
+
+# Create directories
+RUN mkdir -p logs /var/www/static
+
+# Copy dummy keys so settings can load
+RUN cp -r settings/dummy settings/keys 2>/dev/null || true
+
+# Collect static files
+RUN python manage.py collectstatic --noinput 2>/dev/null || true
+
+EXPOSE 8000
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ Develop
 Here are some instructions for setting up regluit for development on
 an Ubuntu system. If you are on OS X see notes below.
 
+Docker development
+
+1. `docker compose up -d`
+1. `docker compose exec web python manage.py migrate --noinput`
+1. `docker compose exec web python manage.py loaddata core/fixtures/initial_data.json core/fixtures/bookloader.json`
+1. Point your browser to http://localhost:8000/
+
+The Docker setup uses `regluit.settings.docker`, starts MySQL and Redis automatically, and keeps the repository bind-mounted into the `web` container for live code edits.
+
 
 - Ensure MySQL 5.7 and Redis are installed & running on your system.
 1. Create a MySQL database and user for unglueit.
@@ -135,4 +144,3 @@ MySQL Migration
 * Many migration blockers were removed by by dumping, then restoring the database.
 * After that, RDS was able to migrate
 * needed to create the unglueit user from the mysql client
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+services:
+  db:
+    image: mysql:8.0
+    volumes:
+      - regluit_mysql:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: regluit
+      MYSQL_DATABASE: unglueit
+      MYSQL_USER: regluit
+      MYSQL_PASSWORD: regluit
+    ports:
+      - "3307:3306"  # avoid conflict with host MySQL
+    command: --character-set-server=utf8 --collation-server=utf8_bin --default-authentication-plugin=mysql_native_password
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-pregluit"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6380:6379"  # avoid conflict with host Redis
+
+  web:
+    build: .
+    volumes:
+      - .:/opt/regluit
+    ports:
+      - "8000:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    environment:
+      DJANGO_SETTINGS_MODULE: regluit.settings.docker
+      PYTHONPATH: /opt
+      DATABASE_USER: regluit
+      DATABASE_PASSWORD: regluit
+      DATABASE_HOST: db
+
+volumes:
+  regluit_mysql:

--- a/settings/docker.py
+++ b/settings/docker.py
@@ -1,0 +1,85 @@
+# coding=utf-8
+# Docker development settings
+from .common import *
+from .dummy.host import *
+
+DEBUG = True
+TEMPLATES[0]['OPTIONS']['debug'] = DEBUG
+
+IS_PREVIEW = False
+SITE_ID = 3
+
+ALLOWED_HOSTS = ['*']
+
+ADMINS = (
+    ('Docker Dev', 'dev@localhost'),
+)
+MANAGERS = ADMINS
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'unglueit',
+        'USER': DATABASE_USER,
+        'PASSWORD': DATABASE_PASSWORD,
+        'HOST': DATABASE_HOST,
+        'PORT': '3306',
+        'TEST': {
+            'CHARSET': 'utf8',
+        },
+        'OPTIONS': {
+            'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
+        }
+    }
+}
+
+TIME_ZONE = 'America/New_York'
+
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+REDIRECT_IS_HTTPS = False
+BASE_URL_SECURE = 'http://localhost:8000'
+
+# Celery uses Redis in Docker
+BROKER_URL = 'redis://redis:6379/0'
+CELERY_RESULT_BACKEND = 'redis://redis:6379/1'
+
+WORKER_HIJACK_ROOT_LOGGER = False
+
+STATIC_ROOT = '/var/www/static'
+
+CELERYBEAT_SCHEDULE = {}
+
+MAINTENANCE_MODE = False
+
+# Cloudflare Turnstile (disabled for local dev)
+CF_TURNSTILE_SITE_KEY = ''
+CF_TURNSTILE_SECRET_KEY = ''
+
+# Dummy Mailchimp key that passes format validation without looking like a real secret
+MAILCHIMP_API_KEY = ('0' * 32) + '-us2'
+MAILCHIMP_NEWS_ID = '0000000000'
+
+SASS_OUTPUT_STYLE = 'compressed'
+
+# Disable SASS compilation for Docker dev (use pre-compiled CSS)
+SASS_PROCESSOR_ENABLED = False
+
+# Log to console in Docker
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        '': {
+            'handlers': ['console'],
+            'level': 'INFO',
+            'propagate': True,
+        },
+    },
+}


### PR DESCRIPTION
## Summary
- add a Dockerfile, Compose stack, and Docker-specific Django settings for local development
- document the Docker quick start in the README
- fix clean image builds by installing g++ for libsass, using /opt on PYTHONPATH, and trimming local build-context noise

## Testing
- docker compose build web
- docker compose up -d web
- docker compose exec -T web python manage.py check --settings=regluit.settings.docker