### PR TITLE
Remove dead SEND_TEST_EMAIL_JOB ("HiThere" test task)

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -378,12 +378,6 @@ CELERY_LOG_DIR = ""
 from celery.schedules import crontab
 # define some periodic tasks
 
-SEND_TEST_EMAIL_JOB = {
-    "task": "regluit.core.tasks.send_mail_task",
-    "schedule": crontab(minute='0,5,10'),
-    "args": ('hi there 20,25,30', 'testing 1, 2, 3', 'notices@gluejar.com', ['unglueit@ebookfoundation.org'])
-}
-
 UPDATE_ACTIVE_CAMPAIGN_STATUSES = {
     "task": "regluit.core.tasks.update_active_campaign_status",
     "schedule": crontab(day_of_month='*', hour=0, minute=1),

--- a/settings/dev.py
+++ b/settings/dev.py
@@ -69,7 +69,6 @@ INTERNAL_IPS = ('127.0.0.1',)
 CELERYBEAT_SCHEDULE = {}
 
 # decide which of the period tasks to add to the schedule
-#CELERYBEAT_SCHEDULE['send_test_email'] = SEND_TEST_EMAIL_JOB
 #CELERYBEAT_SCHEDULE['refresh_acqs'] = REFRESH_ACQS_JOB
 
 # if you're doing development work, you'll want this to be zero


### PR DESCRIPTION
Closes part of [#1131](https://github.com/Gluejar/regluit/issues/1131).

## Why

The `SEND_TEST_EMAIL_JOB` in `settings/common.py` is a dev-era artifact that mails `unglueit@ebookfoundation.org` 72 times/day whenever a deploy is tagged `deploy_type=test`.

- **Production**: never registered (`'prod' == 'test'` is False in the rendered `prod.py`)
- **test.unglue.it historical**: fired **1,796 times through 2026-02-24**, sending `"hi there 20,25,30"` / `"testing 1, 2, 3"` to Eric's inbox
- **test.unglue.it today**: silent because `deploy_type=dev` doesn't match either branch of the template conditional, and celerybeat is in `failed` state there anyway

No functional purpose; no replacement needed.

## What this PR changes

- Deletes `SEND_TEST_EMAIL_JOB` definition from `settings/common.py`
- Deletes the commented-out `#CELERYBEAT_SCHEDULE['send_test_email'] = ...` line from `settings/dev.py` so no symbol dangles

```diff
- SEND_TEST_EMAIL_JOB = {
-     "task": "regluit.core.tasks.send_mail_task",
-     "schedule": crontab(minute='0,5,10'),
-     "args": ('hi there 20,25,30', 'testing 1, 2, 3', 'notices@gluejar.com', ['unglueit@ebookfoundation.org'])
- }
```

## Companion PR

The Ansible template that references `SEND_TEST_EMAIL_JOB` and `SAVE_INFO_PAGE_TEST` lives in `regluit-provisioning`. Companion PR removing the `if '{{ deploy_type }}' == 'test':` branch is being filed alongside: see [EbookFoundation/regluit-provisioning#XX](https://github.com/EbookFoundation/regluit-provisioning/pulls) (linked from issue #1131 once open).

**Merge order doesn't matter in practice**: the test branch of the template was already broken (it references `SAVE_INFO_PAGE_TEST`, which isn't defined anywhere). Removing the symbol without removing the reference is net-neutral — the template was never going to work if the `test` conditional ever matched.

## Test plan

- [x] Grep confirms no other references to `SEND_TEST_EMAIL_JOB` in `regluit`
- [ ] After merge and deploy: `grep -c send_mail_task /var/log/celery/w1.log` on test.unglue.it stays at 0
- [ ] No regression: prod's scheduled tasks (campaign statuses, ebook notifications, etc.) continue to run unchanged — none of them were in the removed branch

## Related

- [#1131](https://github.com/Gluejar/regluit/issues/1131) — tracking issue with full analysis
- [EbookFoundation/security-private#11](https://github.com/EbookFoundation/security-private/issues/11) — email-flood post-mortem (surfaced this during HiThere hunt)
- [#1128](https://github.com/Gluejar/regluit/pull/1128) — rate-limit AdminEmailHandler (different vector, same overall "admin mailbox hygiene" theme)