### PR TITLE
Fix #1136: 500 in /accounts/register/ when notarobot input isn't an int

### DIFF
--- a/libraryauth/forms.py
+++ b/libraryauth/forms.py
@@ -96,7 +96,10 @@ class UserNamePass(UserData):
         return password2
 
     def clean_notarobot(self):
-        notarobot = int(self.data["notarobot"])
+        try:
+            notarobot = int(self.data["notarobot"])
+        except (ValueError, TypeError, KeyError):
+            raise forms.ValidationError("(Hint: it's addition)")
         encoded_answer = self.encode_answers.get(notarobot, 'miss')
         tries = self.data.get("tries", -1)
         if str(encoded_answer) != tries:


### PR DESCRIPTION
Fixes #1136 — stops the registration form from returning a 500 (and emailing admins) when the `notarobot` POST field can't be parsed as an int (e.g. `'14.'` from a bot probe, or a fat-fingered legitimate user).

## Why

`clean_notarobot` reads `self.data["notarobot"]` (raw POST string) and calls `int()` on it directly, bypassing the `IntegerField`'s own `to_python`. Any non-int value raises `ValueError`, which Django doesn't recognize as a form error and surfaces as a 500. Currently noisy on prod due to bot traffic — see #1136 for the full traceback.

## Change

Wrap the `int()` in try/except and raise `forms.ValidationError` with the existing hint message. Minimal diff; preserves behavior for well-formed submissions.

```python
try:
    notarobot = int(self.data["notarobot"])
except (ValueError, TypeError, KeyError):
    raise forms.ValidationError("(Hint: it's addition)")
```

## Not addressed here (deliberately)

The deeper cleanup — reading from `self.cleaned_data` instead of `self.data`, and fixing the `tries` default type mismatch — is described in #1136 but left for a follow-up to keep this PR small and easy to deploy.

## Test plan

- [ ] Submit registration form with `notarobot = '14.'` → form re-renders with hint message, no 500.
- [ ] Submit with correct numeric answer → registration proceeds as before.
- [ ] Submit with wrong numeric answer → form re-renders with hint (existing behavior).
- [ ] Confirm no admin error email is generated for the malformed case.