### PR TITLE
Release: notarobot 500 fix (#1137)

### DIFF
--- a/libraryauth/forms.py
+++ b/libraryauth/forms.py
@@ -96,7 +96,10 @@ class UserNamePass(UserData):
         return password2
 
     def clean_notarobot(self):
-        notarobot = int(self.data["notarobot"])
+        try:
+            notarobot = int(self.data["notarobot"])
+        except (ValueError, TypeError, KeyError):
+            raise forms.ValidationError("(Hint: it's addition)")
         encoded_answer = self.encode_answers.get(notarobot, 'miss')
         tries = self.data.get("tries", -1)
         if str(encoded_answer) != tries:


### PR DESCRIPTION
Release: include #1137 (notarobot 500 fix on /accounts/register/).

## Why now

Smaller-than-usual release — just one fix — but the bug is hot:
- Bot probes with malformed `notarobot` (e.g. `14.`) generate 500s + admin emails on every hit
- Already verified end-to-end on test.unglue.it (see #1137 verification table)

## Contents

- 635f462 Fix 500 in clean_notarobot when notarobot input isn't an int (#1137 → fixes #1136)

## Deploy plan after merge

```bash
cd ~/C/src/EbookFoundation/regluit-provisioning
ANSIBLE_VAULT_PASSWORD_FILE=/Volumes/ryvault1/ebookfoundation/vault_pass.txt \
  ansible-playbook -i hosts setup-prod.yml \
  --private-key=/Volumes/ryvault1/gluejar/EC2_Keys/production.pem
```

Smoke test post-deploy: `POST /accounts/register/` with `notarobot=14.` → 200, not 500.
