### PR TITLE
Release 2026-05-13: DOAB OAI 429 fixes (#1143 + #1144)

### DIFF
--- a/core/loaders/doab.py
+++ b/core/loaders/doab.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # encoding: utf-8
+import collections
 import datetime
+import email.utils
 import logging
 import re
 import urllib.error
@@ -495,6 +497,7 @@ def load_doab_oai(from_date, until_date, limit=100):
     num_doabs = 0
     new_doabs = 0
     lasttime = datetime.datetime(2000, 1, 1)
+    error = None
     try:
         for record in doab_client.listRecords(metadataPrefix='oai_dc', from_=from_,
                                               until=until_date):
@@ -527,13 +530,72 @@ def load_doab_oai(from_date, until_date, limit=100):
         pass
     except urllib.error.HTTPError as e:
         if e.code == 429:
-            retry_after = e.headers.get('Retry-After', 'unknown')
-            logger.error(
-                'DOAB OAI rate-limited (HTTP 429). '
-                'Retry-After: %s seconds. Harvest stopped after %s records.',
-                retry_after, num_doabs
-            )
+            error = _build_rate_limited_error(e.headers, num_doabs)
         else:
             raise
-    return num_doabs, new_doabs, lasttime
+    return num_doabs, new_doabs, lasttime, error
+
+
+# Structured error returned by load_doab_oai when DOAB OAI rate-limits us.
+# Callers (the load_doab management command) read retry_after_seconds to set
+# a deadline; retry_after_raw is the unmodified header value for diagnostics.
+RateLimitedError = collections.namedtuple(
+    'RateLimitedError',
+    ['kind', 'retry_after_seconds', 'retry_after_raw'],
+)
+
+# Conservative fallback if Retry-After is missing or unparseable (RFC 9110
+# allows either delta-seconds or HTTP-date; in the wild DOAB sends seconds).
+_RATE_LIMITED_FALLBACK_SECONDS = 3600  # 1 hour
+
+
+def _build_rate_limited_error(headers, num_doabs):
+    raw = headers.get('Retry-After')
+    seconds = _parse_retry_after(raw)
+    if seconds is None:
+        logger.error(
+            'DOAB OAI rate-limited (HTTP 429); Retry-After missing or unparseable '
+            '(raw=%r). Falling back to %s seconds. Harvest stopped after %s records.',
+            raw, _RATE_LIMITED_FALLBACK_SECONDS, num_doabs,
+        )
+        seconds = _RATE_LIMITED_FALLBACK_SECONDS
+    else:
+        logger.error(
+            'DOAB OAI rate-limited (HTTP 429). Retry-After: %s seconds '
+            '(raw=%r). Harvest stopped after %s records.',
+            seconds, raw, num_doabs,
+        )
+    return RateLimitedError(
+        kind='rate_limited',
+        retry_after_seconds=seconds,
+        retry_after_raw=raw,
+    )
+
+
+def _parse_retry_after(raw):
+    """Parse a Retry-After header value per RFC 9110 §10.2.3.
+
+    Returns an int number of seconds (>= 0), or None if the value is missing
+    or cannot be parsed. Accepts both forms:
+      - delta-seconds: "86400"
+      - HTTP-date:     "Wed, 21 Oct 2026 07:28:00 GMT"
+    """
+    if not raw:
+        return None
+    raw = raw.strip()
+    try:
+        seconds = int(raw)
+        return max(0, seconds)
+    except ValueError:
+        pass
+    try:
+        target = email.utils.parsedate_to_datetime(raw)
+    except (TypeError, ValueError):
+        return None
+    if target is None:
+        return None
+    if target.tzinfo is None:
+        target = target.replace(tzinfo=datetime.timezone.utc)
+    now = datetime.datetime.now(datetime.timezone.utc)
+    return max(0, int((target - now).total_seconds()))
     

--- a/core/management/commands/load_doab.py
+++ b/core/management/commands/load_doab.py
@@ -24,6 +24,13 @@ class Command(BaseCommand):
         max = options['max']
         self.stdout.write('starting at date:{} until:{}, max: {}'.format(
                           from_date, until_date, max))
-        records, new_doabs, last_time = doab.load_doab_oai(from_date, until_date, limit=max)
+        records, new_doabs, last_time, error = doab.load_doab_oai(from_date, until_date, limit=max)
+        if error is not None:
+            self.stdout.write(
+                'ERROR: DOAB OAI rate-limited (HTTP 429), '
+                'retry-after={}s (raw={!r})'.format(
+                    error.retry_after_seconds, error.retry_after_raw,
+                )
+            )
         self.stdout.write('loaded {} records ({} new), ending at {}'.format(
             records, new_doabs, last_time))

--- a/core/management/commands/load_doab.py
+++ b/core/management/commands/load_doab.py
@@ -1,13 +1,76 @@
 import datetime
+import os
+import sys
+import traceback
+
 from django.core.management.base import BaseCommand
 
 from regluit.core.loaders import doab
 
+# Persisted across cron runs so we honor DOAB's Retry-After instead of
+# re-attempting inside the ban window (which extends the ban).
+#
+# Lives under /var/log/regluit because that directory already exists on prod,
+# is writable by the deploy user, and is excluded from the daily log-cleanup
+# cron (which targets `*.log` and `*.log.*` only). Override with the
+# DOAB_OAI_SENTINEL_PATH environment variable for non-prod environments.
+DEFAULT_SENTINEL = '/var/log/regluit/doab-oai-retry-after.state'
+SENTINEL_PATH = os.environ.get('DOAB_OAI_SENTINEL_PATH', DEFAULT_SENTINEL)
+
+
 def timefromiso(datestring):
     try:
         return datetime.datetime.strptime(datestring, "%Y-%m-%d")
-    except:
+    except ValueError:
         return datetime.datetime.strptime(datestring, "%Y-%m-%dT%H:%M:%S")
+
+
+def _now_utc():
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def read_block_deadline(path=SENTINEL_PATH):
+    """Return the persisted Retry-After deadline (tz-aware UTC), or None."""
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path) as f:
+            raw = f.read().strip()
+        if not raw:
+            return None
+        parsed = datetime.datetime.fromisoformat(raw)
+    except (ValueError, OSError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=datetime.timezone.utc)
+    return parsed
+
+
+def write_block_deadline(deadline, path=SENTINEL_PATH, stderr=None):
+    """Persist the deadline; on failure, write a loud traceback to stderr.
+
+    Silent failures here would mask permission/path bugs and reintroduce the
+    ban-extension loop this whole patch exists to prevent.
+    """
+    try:
+        with open(path, 'w') as f:
+            f.write(deadline.isoformat())
+        return True
+    except OSError:
+        target = stderr if stderr is not None else sys.stderr
+        target.write(
+            'WARN: failed to persist DOAB OAI Retry-After sentinel at {}\n'.format(path)
+        )
+        traceback.print_exc(file=target)
+        return False
+
+
+def clear_sentinel(path=SENTINEL_PATH):
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
 
 class Command(BaseCommand):
     help = "load doab books via oai"
@@ -18,19 +81,40 @@ class Command(BaseCommand):
         parser.add_argument('--until', nargs='?', type=timefromiso,
                             default=None, help="YYYY-MM-DD to end")
         parser.add_argument('--max', nargs='?', type=int, default=None, help="max desired records")
+        parser.add_argument('--ignore-retry-after', action='store_true',
+                            help="bypass the persisted Retry-After block (operator override)")
 
     def handle(self, from_date, **options):
         until_date = options['until']
         max = options['max']
+        ignore = options['ignore_retry_after']
+
+        deadline = read_block_deadline()
+        now = _now_utc()
+        if deadline and now < deadline and not ignore:
+            self.stdout.write(
+                'SKIP: DOAB OAI rate-limited until {} (honoring Retry-After). '
+                'Use --ignore-retry-after to override.'.format(deadline.isoformat())
+            )
+            return
+        if deadline and now >= deadline:
+            clear_sentinel()
+
         self.stdout.write('starting at date:{} until:{}, max: {}'.format(
                           from_date, until_date, max))
         records, new_doabs, last_time, error = doab.load_doab_oai(from_date, until_date, limit=max)
+
         if error is not None:
+            new_deadline = _now_utc() + datetime.timedelta(seconds=error.retry_after_seconds)
+            wrote = write_block_deadline(new_deadline, stderr=self.stderr)
             self.stdout.write(
                 'ERROR: DOAB OAI rate-limited (HTTP 429), '
-                'retry-after={}s (raw={!r})'.format(
+                'retry-after={}s (raw={!r}). {} blocked until {}'.format(
                     error.retry_after_seconds, error.retry_after_raw,
+                    'Persisted sentinel:' if wrote else 'Sentinel write failed;',
+                    new_deadline.isoformat(),
                 )
             )
+
         self.stdout.write('loaded {} records ({} new), ending at {}'.format(
             records, new_doabs, last_time))


### PR DESCRIPTION
Production release bundling the two DOAB OAI rate-limit fixes that landed on master today:

- Gluejar/regluit#1143 — Surface DOAB OAI 429 errors in load_doab cron output (visibility)
- Gluejar/regluit#1144 — Respect DOAB OAI Retry-After across cron runs (stops daily ban-extension loop)

Eric verbally endorsed both at the 2026-05-07 meeting. Polish pass after Codex review (structured error, RFC 9110 Retry-After parsing, 1h fallback, tz-aware UTC, durable sentinel path, loud failures) — see PR comments for details.

Floor of the four-level DOAB plan; step B (bitstream 429 circuit breaker) and step C (upstream pyoai PR) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)