### PR TITLE
Add DOAB bitstream API circuit breaker (HTTP 429)

### DIFF
--- a/core/loaders/doab.py
+++ b/core/loaders/doab.py
@@ -2,7 +2,6 @@
 # encoding: utf-8
 import collections
 import datetime
-import email.utils
 import logging
 import re
 import urllib.error
@@ -30,7 +29,10 @@ from regluit.core.validation import identifier_cleaner, valid_subject, explode_b
 
 from . import scrape_language
 from .doab_utils import (
-    doab_lang_to_iso_639_1, doab_cover, doab_reader, online_to_download, STOREPROVIDERS)
+    bitstream_breaker_open, bitstream_breaker_trip,
+    doab_lang_to_iso_639_1, doab_cover, doab_reader, online_to_download,
+    parse_retry_after, STOREPROVIDERS,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +49,7 @@ def store_doab_cover(doab_id, redo=False):
     returns tuple: 1) cover URL, 2) whether newly created (boolean)
     """
     if not doab_id:
-        return (None, False)    
+        return (None, False)
 
     cover_file_name = '/doab/%s' % doab_id
 
@@ -56,13 +58,29 @@ def store_doab_cover(doab_id, redo=False):
     if not redo and default_storage.exists(cover_file_name):
         return (default_storage.url(cover_file_name), False)
 
+    # When the DOAB bitstream breaker is open, skip new downloads. Note: the
+    # default_storage.exists() check above still serves cached covers from
+    # our S3 bucket even while DOAB is banning us.
+    if bitstream_breaker_open():
+        return (None, False)
+
     # download cover image to cover_file
     url = doab_cover(doab_id)
     headers = {"User-Agent": settings.USER_AGENT}
     if not url:
         return (None, False)
     try:
+        # First request is to directory.doabooks.org — a 429 here trips the
+        # DOAB breaker. Subsequent requests after a redirect may go to other
+        # hosts (e.g. images.springer.com), where 429 should NOT be attributed
+        # to DOAB's rate limit.
         r = requests.get(url, allow_redirects=False, headers=headers, timeout=(5, 60)) # requests doesn't handle ftp redirects.
+        if r.status_code == 429:
+            bitstream_breaker_trip(
+                r.headers.get('Retry-After'),
+                'store_doab_cover({})'.format(doab_id),
+            )
+            return (None, False)
         if r.status_code == 302:
             redirurl = r.headers['Location']
             if redirurl.startswith(u'ftp'):
@@ -551,7 +569,7 @@ _RATE_LIMITED_FALLBACK_SECONDS = 3600  # 1 hour
 
 def _build_rate_limited_error(headers, num_doabs):
     raw = headers.get('Retry-After')
-    seconds = _parse_retry_after(raw)
+    seconds = parse_retry_after(raw)
     if seconds is None:
         logger.error(
             'DOAB OAI rate-limited (HTTP 429); Retry-After missing or unparseable '
@@ -570,32 +588,4 @@ def _build_rate_limited_error(headers, num_doabs):
         retry_after_seconds=seconds,
         retry_after_raw=raw,
     )
-
-
-def _parse_retry_after(raw):
-    """Parse a Retry-After header value per RFC 9110 §10.2.3.
-
-    Returns an int number of seconds (>= 0), or None if the value is missing
-    or cannot be parsed. Accepts both forms:
-      - delta-seconds: "86400"
-      - HTTP-date:     "Wed, 21 Oct 2026 07:28:00 GMT"
-    """
-    if not raw:
-        return None
-    raw = raw.strip()
-    try:
-        seconds = int(raw)
-        return max(0, seconds)
-    except ValueError:
-        pass
-    try:
-        target = email.utils.parsedate_to_datetime(raw)
-    except (TypeError, ValueError):
-        return None
-    if target is None:
-        return None
-    if target.tzinfo is None:
-        target = target.replace(tzinfo=datetime.timezone.utc)
-    now = datetime.datetime.now(datetime.timezone.utc)
-    return max(0, int((target - now).total_seconds()))
     

--- a/core/loaders/doab_utils.py
+++ b/core/loaders/doab_utils.py
@@ -2,8 +2,14 @@
 doab_utils.py
 
 """
+import datetime
+import email.utils
 import logging
+import os
 import re
+import sys
+import threading
+import traceback
 from ssl import SSLError
 from urllib.parse import urljoin
 
@@ -19,6 +25,175 @@ from .soup import get_soup
 
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# DOAB rate-limit helpers
+#
+# Two endpoints on directory.doabooks.org get rate-limited together:
+#   - OAI-PMH (used by load_doab_oai in doab.py)
+#   - REST/bitstream (used by get_streamdata here and the cover download in
+#     doab.py's store_doab_cover)
+#
+# The OAI path uses a cross-cron sentinel (see core/management/commands/
+# load_doab.py). The bitstream path is called per-record inside the OAI
+# harvest loop, so it uses an in-process circuit breaker that also persists
+# a sentinel — once tripped, all bitstream calls (in this process or the
+# next cron run) return None until the deadline passes.
+# ---------------------------------------------------------------------------
+
+_BITSTREAM_FALLBACK_SECONDS = 3600  # 1 hour if Retry-After is missing/unparseable
+_DEFAULT_BITSTREAM_SENTINEL = '/var/log/regluit/doab-bitstream-retry-after.state'
+BITSTREAM_SENTINEL_PATH = os.environ.get(
+    'DOAB_BITSTREAM_SENTINEL_PATH', _DEFAULT_BITSTREAM_SENTINEL,
+)
+
+_bitstream_lock = threading.Lock()
+_bitstream_breaker_until = None  # tz-aware UTC datetime, or None
+_bitstream_breaker_loaded = False  # have we read the sentinel file yet?
+
+
+def parse_retry_after(raw):
+    """Parse a Retry-After header value per RFC 9110 §10.2.3.
+
+    Returns an int number of seconds (>= 0), or None if the value is missing
+    or cannot be parsed. Accepts both delta-seconds and HTTP-date forms.
+    """
+    if not raw:
+        return None
+    raw = raw.strip()
+    try:
+        seconds = int(raw)
+        return max(0, seconds)
+    except ValueError:
+        pass
+    try:
+        target = email.utils.parsedate_to_datetime(raw)
+    except (TypeError, ValueError):
+        return None
+    if target is None:
+        return None
+    if target.tzinfo is None:
+        target = target.replace(tzinfo=datetime.timezone.utc)
+    now = datetime.datetime.now(datetime.timezone.utc)
+    return max(0, int((target - now).total_seconds()))
+
+
+def _now_utc():
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def _read_bitstream_sentinel(path=None):
+    path = path or BITSTREAM_SENTINEL_PATH
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path) as f:
+            raw = f.read().strip()
+        if not raw:
+            return None
+        parsed = datetime.datetime.fromisoformat(raw)
+    except (ValueError, OSError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=datetime.timezone.utc)
+    return parsed
+
+
+def _write_bitstream_sentinel(deadline, path=None):
+    path = path or BITSTREAM_SENTINEL_PATH
+    try:
+        with open(path, 'w') as f:
+            f.write(deadline.isoformat())
+        return True
+    except OSError:
+        sys.stderr.write(
+            'WARN: failed to persist DOAB bitstream Retry-After sentinel at {}\n'.format(path)
+        )
+        traceback.print_exc(file=sys.stderr)
+        return False
+
+
+def _clear_bitstream_sentinel(path=None):
+    path = path or BITSTREAM_SENTINEL_PATH
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
+
+def bitstream_breaker_open():
+    """True when the DOAB bitstream circuit breaker is tripped.
+
+    On first call in a process, reads the persisted sentinel so a fresh cron
+    run honors the deadline set by a previous run. Logs once when a fresh
+    process loads an already-open sentinel, so operators see "this cron ran
+    but skipped all cover work due to a persisted ban window."
+    """
+    global _bitstream_breaker_until, _bitstream_breaker_loaded
+    log_loaded = None  # (deadline,) when we should emit the once-per-process load log
+    with _bitstream_lock:
+        if not _bitstream_breaker_loaded:
+            _bitstream_breaker_until = _read_bitstream_sentinel()
+            _bitstream_breaker_loaded = True
+            if _bitstream_breaker_until and _now_utc() < _bitstream_breaker_until:
+                log_loaded = (_bitstream_breaker_until,)
+        if _bitstream_breaker_until is None:
+            is_open = False
+        elif _now_utc() < _bitstream_breaker_until:
+            is_open = True
+        else:
+            # deadline passed — clear in-memory and on-disk
+            _bitstream_breaker_until = None
+            _clear_bitstream_sentinel()
+            is_open = False
+    if log_loaded is not None:
+        logger.info(
+            'DOAB bitstream circuit breaker loaded from sentinel; open until '
+            '%s. Cover lookups will be skipped until then.',
+            log_loaded[0].isoformat(),
+        )
+    return is_open
+
+
+def bitstream_breaker_trip(retry_after_raw, source):
+    """Open the circuit breaker. Called when a bitstream endpoint returns 429.
+
+    `source` is a short human label (e.g. "get_streamdata(20.500.12854/176298)")
+    used in the single per-trip log line so operators can see which endpoint
+    tripped the breaker.
+    """
+    global _bitstream_breaker_until, _bitstream_breaker_loaded
+    seconds = parse_retry_after(retry_after_raw)
+    if seconds is None:
+        seconds = _BITSTREAM_FALLBACK_SECONDS
+    deadline = _now_utc() + datetime.timedelta(seconds=seconds)
+    # Hold the lock across the disk write so two threads can't write out of
+    # order and leave the shorter deadline persisted. (Two *processes* can
+    # still race here, but that's tolerable — cron's only writer in practice
+    # is a single load_doab run; the cross-process loss case shortens a ban
+    # by at most one Retry-After delta, which is acceptable.)
+    with _bitstream_lock:
+        if _bitstream_breaker_until and _bitstream_breaker_until > deadline:
+            return _bitstream_breaker_until
+        _bitstream_breaker_until = deadline
+        _bitstream_breaker_loaded = True
+        _write_bitstream_sentinel(deadline)
+    logger.error(
+        'DOAB bitstream API rate-limited (HTTP 429) from %s; circuit breaker '
+        'open until %s (retry-after raw=%r, parsed=%ss). Suppressing further '
+        'per-record 429 logs.',
+        source, deadline.isoformat(), retry_after_raw, seconds,
+    )
+    return deadline
+
+
+def _bitstream_breaker_reset_for_tests():
+    """Test-only hook: reset module state."""
+    global _bitstream_breaker_until, _bitstream_breaker_loaded
+    with _bitstream_lock:
+        _bitstream_breaker_until = None
+        _bitstream_breaker_loaded = False
 
 def doab_lang_to_iso_639_1(lang):
     lang = lang_to_language_code(lang)
@@ -125,12 +300,16 @@ def online_to_download(url):
 STREAM_QUERY = 'https://directory.doabooks.org/rest/search?query=handle:{}&expand=bitstreams'
 
 def get_streamdata(handle):
+    if bitstream_breaker_open():
+        return None
     url = STREAM_QUERY.format(handle)
     try:
         response = requests.get(url, headers={"User-Agent": settings.USER_AGENT}, timeout=(5, 60))
         if response.status_code == 429:
-            retry_after = response.headers.get('Retry-After', 'unknown')
-            logger.error('DOAB bitstream API rate-limited (HTTP 429) for %s. Retry-After: %s', handle, retry_after)
+            bitstream_breaker_trip(
+                response.headers.get('Retry-After'),
+                'get_streamdata({})'.format(handle),
+            )
             return None
         items = response.json()
         if items:


### PR DESCRIPTION
Step B of the DOAB rate-limit plan — follow-up to #1143/#1144 (OAI sentinel, merged + deployed today). Codex flagged the bitstream 429s as a separate hole and recommended a circuit-breaker pattern (not the cross-cron sentinel pattern), noting both `get_streamdata()` and the cover download inside `store_doab_cover()` need handling.

## What this does

- Adds an in-process circuit breaker in `core.loaders.doab_utils` for the DOAB bitstream/REST endpoints. While open, calls return None without HTTP requests.
- Persists the deadline to a sentinel file (`/var/log/regluit/doab-bitstream-retry-after.state` by default; `DOAB_BITSTREAM_SENTINEL_PATH` env override) so subsequent cron runs honor the same window without an extra hit.
- Moves `parse_retry_after()` (RFC 9110 delta-seconds OR HTTP-date) from `doab.py` to `doab_utils.py` so both the OAI and bitstream paths share the parser.
- Single ERROR log per trip; INFO log once on persisted-sentinel load. No more per-record 429 spam (was ~14/run on May 8).
- Patches both endpoints: `get_streamdata()` and the cover `requests.get()` call inside `store_doab_cover()`.

## Doesn't stall OAI harvesting

Only cover work is skipped while the bitstream breaker is open. Each cover lookup returns None (= no cover stored); the harvest continues processing the record.

## Codex review feedback applied (commit `ba6badc4` amends initial commit)

1. **Wrong-host 429 attribution removed** — post-302-redirect 429 check at `store_doab_cover` was attributing 429s from `images.springer.com` (FTP→HTTPS rewrite path) to the DOAB breaker. Removed; only the first request (always to `directory.doabooks.org`) trips the breaker.
2. **Lock-then-write race fixed** — sentinel write moved inside the lock, so two threads can't race the disk and leave a shorter deadline persisted. Cross-process race acknowledged as tolerable (only writer in practice is a single cron run).
3. **Persisted-sentinel load now logs INFO** — operators can see when a fresh cron loads an already-open sentinel and skips all cover work. Was previously silent.
4. Comment at `store_doab_cover` tightened — cached covers in S3 are still served while DOAB is rate-limiting us.

## Tests

10/10 local unit tests for the breaker (closed by default, trip opens, persisted sentinel survives process restart, expired sentinel clears state, unparseable/None Retry-After falls back to 1h, shorter trip doesn't shrink active window).

## Note on doab-check

doab-check has the same `get_streamdata` code but no callers (dead code inherited from regluit when it was forked). Patch confined to regluit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)