### PR TITLE
Release 2026-05-13c: pin pyoai to EbookFoundation fork (#1149)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -118,7 +118,7 @@ wikipedia = "==1.4.0"
 django-email-change = {editable = true, ref = "fb063296cbf4e4a6d8a93d34d98fe0c7739c2e0d", git = "git+https://github.com/eshellman/django-email-change.git"}
 django-notification = {editable = true, ref = "1ad2be4adf3551a3471d923380368341452e178a", git = "git+https://github.com/eshellman/django-notification.git"}
 pyjwt = {extras = ["crypto"], version = "==2.8.0"}
-pyoai = {editable = true, ref = "5ff2f15e869869e70d8139e4c37b7832854d7049", git = "git+https://github.com/infrae/pyoai.git"}
+pyoai = {editable = true, ref = "bf709d26ae6e4b34b9b0ca726e0f032d97f0bd38", git = "git+https://github.com/EbookFoundation/pyoai.git"}
 
 [requires]
 python_version = "3.9"

--- a/core/loaders/doab.py
+++ b/core/loaders/doab.py
@@ -20,6 +20,16 @@ from django.core.files.storage import default_storage
 from oaipmh.client import Client
 from oaipmh.error import IdDoesNotExistError, NoRecordsMatchError
 from oaipmh.metadata import MetadataRegistry
+try:
+    # The patched pyoai (EbookFoundation/pyoai fix/expose-429-as-rate-limited-error,
+    # pending upstream to eth-library/oaipmh) surfaces 429 cleanly as
+    # RateLimitedError with parsed Retry-After. Stock pyoai (<= 2.5.1)
+    # re-raises urllib HTTPError, handled below as a fallback.
+    from oaipmh.client import RateLimitedError as _PyOAIRateLimitedError
+except ImportError:
+    class _PyOAIRateLimitedError(Exception):
+        """Never-raised placeholder for stock (unpatched) pyoai."""
+        pass
 
 from regluit.core import bookloader, cc
 from regluit.core import models, tasks
@@ -546,12 +556,41 @@ def load_doab_oai(from_date, until_date, limit=100):
                 break
     except NoRecordsMatchError:
         pass
+    except _PyOAIRateLimitedError as e:
+        # Patched pyoai: 429 surfaced as structured exception with parsed
+        # Retry-After. Build our local namedtuple from its attributes so
+        # the mgmt command sees the same shape regardless of pyoai version.
+        error = _build_rate_limited_error_from_pyoai(e, num_doabs)
     except urllib.error.HTTPError as e:
         if e.code == 429:
+            # Older pyoai re-raised HTTPError; parse Retry-After ourselves.
             error = _build_rate_limited_error(e.headers, num_doabs)
         else:
             raise
     return num_doabs, new_doabs, lasttime, error
+
+
+def _build_rate_limited_error_from_pyoai(exc, num_doabs):
+    """Wrap a pyoai RateLimitedError into our structured-error namedtuple."""
+    seconds = exc.retry_after_seconds
+    if seconds is None:
+        logger.error(
+            'DOAB OAI rate-limited (HTTP 429); Retry-After missing or unparseable '
+            '(raw=%r). Falling back to %s seconds. Harvest stopped after %s records.',
+            exc.retry_after_raw, _RATE_LIMITED_FALLBACK_SECONDS, num_doabs,
+        )
+        seconds = _RATE_LIMITED_FALLBACK_SECONDS
+    else:
+        logger.error(
+            'DOAB OAI rate-limited (HTTP 429). Retry-After: %s seconds '
+            '(raw=%r). Harvest stopped after %s records.',
+            seconds, exc.retry_after_raw, num_doabs,
+        )
+    return RateLimitedError(
+        kind='rate_limited',
+        retry_after_seconds=seconds,
+        retry_after_raw=exc.retry_after_raw,
+    )
 
 
 # Structured error returned by load_doab_oai when DOAB OAI rate-limits us.

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ pyhanko==0.21.0; python_version >= '3.8'
 pyhanko-certvalidator==0.26.3; python_version >= '3.7'
 pyjwt[crypto]==2.8.0; python_version >= '3.7'
 pymarc==4.2.1; python_version >= '3.6'
--e git+https://github.com/infrae/pyoai.git@5ff2f15e869869e70d8139e4c37b7832854d7049#egg=pyoai
+-e git+https://github.com/EbookFoundation/pyoai.git@bf709d26ae6e4b34b9b0ca726e0f032d97f0bd38#egg=pyoai
 pyopenssl==23.3.0; python_version >= '3.7'
 pyparsing==3.1.1; python_full_version >= '3.6.8'
 pypdf>=5.0.0


### PR DESCRIPTION
Step C of today's DOAB rate-limit plan. Switches pyoai pin from unmaintained infrae/pyoai to our fork carrying the RateLimitedError patch. `load_doab_oai` now catches the new exception first; HTTPError fallback kept for safety.

Upstream PR to eth-library/oaipmh: eth-library/oaipmh#27.
Info issue on infrae/pyoai: infrae/pyoai#63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)