### PR TITLE
Fix #1155: TypeError in Work.publication_date from two-query race

### DIFF
--- a/core/models/bibmodels.py
+++ b/core/models/bibmodels.py
@@ -562,6 +562,7 @@ class Work(models.Model):
             date[:4]
             for date in Edition.objects
                 .filter(work=self, publication_date__isnull=False)
+                .exclude(publication_date='')
                 .order_by('publication_date')
                 .values_list('publication_date', flat=True)
             if date

--- a/core/models/bibmodels.py
+++ b/core/models/bibmodels.py
@@ -553,28 +553,31 @@ class Work(models.Model):
     def publication_date(self):
         if self.publication_range:
             return  self.publication_range
-        for edition in Edition.objects.filter(work=self, publication_date__isnull=False).order_by('publication_date'):
-            if edition.publication_date:
-                try:
-                    earliest_publication = edition.publication_date[:4]
-                except IndexError:
-                    continue
-                latest_publication = None
-                for edition in Edition.objects.filter(work=self, publication_date__isnull=False).order_by('-publication_date'):
-                    if edition.publication_date:
-                        try:
-                            latest_publication = edition.publication_date[:4]
-                        except IndexError:
-                            continue
-                        break
-                if earliest_publication == latest_publication:
-                    publication_range = earliest_publication
-                else:
-                    publication_range = earliest_publication + "-" + latest_publication
-                self.publication_range = publication_range
-                self.save()
-                return publication_range
-        return ''
+        # Derive the range from a single, consistently-evaluated result set.
+        # The previous implementation ran two separate queries (asc + desc); when
+        # the dated-edition set changed between them (e.g. concurrent edition
+        # loading) the second query could find no rows, leaving the "latest" year
+        # None and crashing on `earliest + "-" + None`. See issue #1155.
+        years = [
+            date[:4]
+            for date in Edition.objects
+                .filter(work=self, publication_date__isnull=False)
+                .order_by('publication_date')
+                .values_list('publication_date', flat=True)
+            if date
+        ]
+        if not years:
+            return ''
+        earliest_publication, latest_publication = years[0], years[-1]
+        if earliest_publication == latest_publication:
+            publication_range = earliest_publication
+        else:
+            publication_range = earliest_publication + "-" + latest_publication
+        self.publication_range = publication_range
+        # update_fields avoids clobbering other (possibly stale) in-memory fields
+        # during what is nominally a read.
+        self.save(update_fields=['publication_range'])
+        return publication_range
 
     @property
     def has_unglued_edition(self):

--- a/core/tests.py
+++ b/core/tests.py
@@ -908,6 +908,47 @@ class WorkTests(TestCase):
         self.assertEqual(e2, self.w1.preferred_edition)
         self.assertEqual(e2, self.w2.preferred_edition)
 
+    def test_publication_date_no_editions(self):
+        self.assertEqual(self.w1.publication_date, '')
+
+    def test_publication_date_single_year(self):
+        models.Edition.objects.create(work=self.w1, publication_date='2007')
+        models.Edition.objects.create(work=self.w1, publication_date='2007-08-22')
+        self.assertEqual(self.w1.publication_date, '2007')
+
+    def test_publication_date_range(self):
+        models.Edition.objects.create(work=self.w1, publication_date='2007')
+        models.Edition.objects.create(work=self.w1, publication_date='2017-08-23')
+        self.assertEqual(self.w1.publication_date, '2007-2017')
+
+    def test_publication_date_ignores_blank_and_null(self):
+        # Regression for #1155: editions with NULL/blank publication_date pass the
+        # isnull=False filter (blank) or are simply absent (NULL) and must not
+        # produce a None "latest" year that crashes the range concatenation.
+        models.Edition.objects.create(work=self.w1, publication_date=None)
+        models.Edition.objects.create(work=self.w1, publication_date='')
+        models.Edition.objects.create(work=self.w1, publication_date='2007')
+        models.Edition.objects.create(work=self.w1, publication_date='2017')
+        # Must not raise TypeError, and blanks must not pollute the range.
+        self.assertEqual(self.w1.publication_date, '2007-2017')
+
+    def test_publication_date_only_blank_editions(self):
+        models.Edition.objects.create(work=self.w1, publication_date=None)
+        models.Edition.objects.create(work=self.w1, publication_date='')
+        self.assertEqual(self.w1.publication_date, '')
+
+    def test_publication_date_uses_single_edition_query(self):
+        # Regression for #1155: the uncached path must evaluate the editions once
+        # (1 SELECT) and persist the cache (1 UPDATE) -- not the old two-query
+        # (asc + desc) shape whose inconsistent reads caused the crash.
+        models.Edition.objects.create(work=self.w1, publication_date='2007')
+        models.Edition.objects.create(work=self.w1, publication_date='2017')
+        with self.assertNumQueries(2):
+            self.assertEqual(self.w1.publication_date, '2007-2017')
+        # Now cached: no further queries.
+        with self.assertNumQueries(0):
+            self.assertEqual(self.w1.publication_date, '2007-2017')
+
     def test_valid_subject(self):
         self.assertTrue(valid_subject(u'A, valid, suj\xc3t'))
         self.assertFalse(valid_subject(u'A, valid, suj\xc3t, '))


### PR DESCRIPTION
Fixes #1155 — `/work/<id>/` 500s with `TypeError: can only concatenate str (not "NoneType") to str` because `Work.publication_date` derives its year range from two separately-evaluated edition queries, and an inconsistent read between them leaves the "latest" year `None`.

## Why

`Work.publication_date` ran `Edition...order_by('publication_date')` (ascending) and then a second `Edition...order_by('-publication_date')` (descending), initializing `latest_publication = None` and setting it only from the second query. If the dated-edition set changed between the two reads — consistent with the concurrent DOAB/edition-loading burst observed at the crash second (see #1155 for the timeline evidence) — the second query found no truthy dates and the range concatenation crashed.

## What changed

- `core/models/bibmodels.py`: compute the range from a **single** evaluated queryset (`values_list`, skip falsy dates). Structurally eliminates the two-query inconsistency. `years[0]`/`years[-1]` reproduce the previous earliest/latest semantics.
- Use `save(update_fields=['publication_range'])` so this nominally-read property doesn't persist other (possibly stale) in-memory `Work` fields.
- `core/tests.py` (`WorkTests`): regression coverage — mixed null/blank/valid dates (the crash case), single-year vs range, all-blank → `''`, and an `assertNumQueries` guard proving the single-query shape.

## Validation

- Replayed the new algorithm against the real edition dates of the affected work (114123): yields `2007-2017` (vs the now-stale cached `2007-2009`); edge cases (`only blank → ''`, `single → '2007'`, `mixed null/blank → '2007-2017'`) all correct.
- `py_compile` clean. Reviewed and refined with OpenAI Codex (gpt-5.4).

## Notes / follow-ups (not in this PR)

- `publication_range` is not invalidated when editions change, so cached ranges go stale after backfills.
- `frontend/views/__init__.py:304` `work` view calls `safe_get_work` without catching `Work.DoesNotExist` → likely a separate `/work/<bad-id>/` 500; can file separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
