### PR TITLE
Fix #1156: widget endpoint 500s on unknown/non-numeric/invalid ids

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -50,6 +50,19 @@ class ApiTests(TestCase):
         r = self.client.get('/api/widget/%s/'%self.work_id)
         self.assertEqual(r.status_code, 200)
 
+    def test_widget_unknown_ids_return_empty_widget(self):
+        # Regression for #1156: bad identifiers must render an empty widget (200),
+        # not raise an uncaught exception (500).
+        # non-numeric token (length != 10/13) -> safe_get_work raises Work.DoesNotExist
+        r = self.client.get('/api/widget/featured4iL7gEXx/')
+        self.assertEqual(r.status_code, 200)
+        # numeric but no such work
+        r = self.client.get('/api/widget/999999999/')
+        self.assertEqual(r.status_code, 200)
+        # invalid ISBN-10 -> convert_10_to_13 returns None (was len(None) TypeError)
+        r = self.client.get('/api/widget/ABCDEFGHIJ/')
+        self.assertEqual(r.status_code, 200)
+
 class FeedTests(TestCase):
     fixtures = ['initial_data.json', 'neuromancer.json']
     def setUp(self):

--- a/api/views.py
+++ b/api/views.py
@@ -65,19 +65,29 @@ def widget(request, isbn):
         work = featured_work()
     else :
         if len(isbn)==10:
+            # convert_10_to_13 returns None for an invalid ISBN-10; guard the
+            # len() below and fall through to the empty-widget response.
             isbn = regluit.core.isbn.convert_10_to_13(isbn)
-        if len(isbn)==13:
+        if isbn and len(isbn)==13:
             try:
                 identifier = models.Identifier.objects.get(type = 'isbn', value = isbn )
                 work = identifier.work
             except models.Identifier.DoesNotExist:
                 return render(request, 'widget.html',
-                     { 'work':None,},
+                     { 'work':None, 'isbn':isbn, },
                     )
         else:
-            work= models.safe_get_work(isbn)
+            # isbn may be a work_id, a non-numeric token, or None (invalid
+            # ISBN-10). safe_get_work raises Work.DoesNotExist for unknown or
+            # non-numeric ids; render an empty widget instead of a 500.
+            try:
+                work = models.safe_get_work(isbn)
+            except models.Work.DoesNotExist:
+                return render(request, 'widget.html',
+                     { 'work':None, 'isbn':isbn, },
+                    )
     return render(request, 'widget.html',
-         {'work':work, },
+         {'work':work, 'isbn':isbn, },
      )
 
 def featured_cover(request):


### PR DESCRIPTION
Fixes #1156 — `/api/widget/<id>/` returns 500 for unknown, non-numeric, or invalid identifiers instead of the existing empty-widget response.

## Why

The `widget` view treats any non-`featured`, non-10/13-character token as a work id and calls `safe_get_work(isbn)`. For a token like `featured4iL7gEXx`, `safe_get_work` converts Django's integer-field `ValueError` into `Work.DoesNotExist`, which the view never catches → 500. Two adjacent defects compound it:
- `convert_10_to_13()` returns `None` for an invalid ISBN-10, so the following `len(isbn)` raised `TypeError` (another 500) for any bogus 10-char token.
- `widget.html` renders `...ISBN {{isbn}}...`, but the `work=None` render paths didn't pass `isbn`, so the empty-widget message dropped the identifier.

## What changed (`api/views.py`)

- Wrap `safe_get_work(isbn)` in `try/except models.Work.DoesNotExist` → render the empty widget, matching the existing `Identifier.DoesNotExist` handling.
- Guard the ISBN branch with `if isbn and len(isbn) == 13` so a `None` from `convert_10_to_13` falls through to the empty-widget response instead of `len(None)`.
- Pass `isbn` into every `work=None` render path so the template message renders.

## Tests (`api/tests.py`, `ApiTests`)

- `/api/widget/featured4iL7gEXx/` → 200 (was 500)
- `/api/widget/999999999/` (numeric, no such work) → 200
- `/api/widget/ABCDEFGHIJ/` (invalid ISBN-10) → 200 (was `TypeError` 500)

## Validation

`py_compile` clean; `convert_10_to_13` confirmed to return `None` (not raise) on invalid input. Diagnosis reviewed and refined with OpenAI Codex (gpt-5.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
