### PR TITLE
Release 2026-06-11: prod-500 hotfixes #1157 + #1158

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -50,6 +50,19 @@ class ApiTests(TestCase):
         r = self.client.get('/api/widget/%s/'%self.work_id)
         self.assertEqual(r.status_code, 200)
 
+    def test_widget_unknown_ids_return_empty_widget(self):
+        # Regression for #1156: bad identifiers must render an empty widget (200),
+        # not raise an uncaught exception (500).
+        # non-numeric token (length != 10/13) -> safe_get_work raises Work.DoesNotExist
+        r = self.client.get('/api/widget/featured4iL7gEXx/')
+        self.assertEqual(r.status_code, 200)
+        # numeric but no such work
+        r = self.client.get('/api/widget/999999999/')
+        self.assertEqual(r.status_code, 200)
+        # invalid ISBN-10 -> convert_10_to_13 returns None (was len(None) TypeError)
+        r = self.client.get('/api/widget/ABCDEFGHIJ/')
+        self.assertEqual(r.status_code, 200)
+
 class FeedTests(TestCase):
     fixtures = ['initial_data.json', 'neuromancer.json']
     def setUp(self):

--- a/api/views.py
+++ b/api/views.py
@@ -65,19 +65,29 @@ def widget(request, isbn):
         work = featured_work()
     else :
         if len(isbn)==10:
+            # convert_10_to_13 returns None for an invalid ISBN-10; guard the
+            # len() below and fall through to the empty-widget response.
             isbn = regluit.core.isbn.convert_10_to_13(isbn)
-        if len(isbn)==13:
+        if isbn and len(isbn)==13:
             try:
                 identifier = models.Identifier.objects.get(type = 'isbn', value = isbn )
                 work = identifier.work
             except models.Identifier.DoesNotExist:
                 return render(request, 'widget.html',
-                     { 'work':None,},
+                     { 'work':None, 'isbn':isbn, },
                     )
         else:
-            work= models.safe_get_work(isbn)
+            # isbn may be a work_id, a non-numeric token, or None (invalid
+            # ISBN-10). safe_get_work raises Work.DoesNotExist for unknown or
+            # non-numeric ids; render an empty widget instead of a 500.
+            try:
+                work = models.safe_get_work(isbn)
+            except models.Work.DoesNotExist:
+                return render(request, 'widget.html',
+                     { 'work':None, 'isbn':isbn, },
+                    )
     return render(request, 'widget.html',
-         {'work':work, },
+         {'work':work, 'isbn':isbn, },
      )
 
 def featured_cover(request):

--- a/core/models/bibmodels.py
+++ b/core/models/bibmodels.py
@@ -562,6 +562,7 @@ class Work(models.Model):
             date[:4]
             for date in Edition.objects
                 .filter(work=self, publication_date__isnull=False)
+                .exclude(publication_date='')
                 .order_by('publication_date')
                 .values_list('publication_date', flat=True)
             if date

--- a/core/models/bibmodels.py
+++ b/core/models/bibmodels.py
@@ -553,28 +553,31 @@ class Work(models.Model):
     def publication_date(self):
         if self.publication_range:
             return  self.publication_range
-        for edition in Edition.objects.filter(work=self, publication_date__isnull=False).order_by('publication_date'):
-            if edition.publication_date:
-                try:
-                    earliest_publication = edition.publication_date[:4]
-                except IndexError:
-                    continue
-                latest_publication = None
-                for edition in Edition.objects.filter(work=self, publication_date__isnull=False).order_by('-publication_date'):
-                    if edition.publication_date:
-                        try:
-                            latest_publication = edition.publication_date[:4]
-                        except IndexError:
-                            continue
-                        break
-                if earliest_publication == latest_publication:
-                    publication_range = earliest_publication
-                else:
-                    publication_range = earliest_publication + "-" + latest_publication
-                self.publication_range = publication_range
-                self.save()
-                return publication_range
-        return ''
+        # Derive the range from a single, consistently-evaluated result set.
+        # The previous implementation ran two separate queries (asc + desc); when
+        # the dated-edition set changed between them (e.g. concurrent edition
+        # loading) the second query could find no rows, leaving the "latest" year
+        # None and crashing on `earliest + "-" + None`. See issue #1155.
+        years = [
+            date[:4]
+            for date in Edition.objects
+                .filter(work=self, publication_date__isnull=False)
+                .order_by('publication_date')
+                .values_list('publication_date', flat=True)
+            if date
+        ]
+        if not years:
+            return ''
+        earliest_publication, latest_publication = years[0], years[-1]
+        if earliest_publication == latest_publication:
+            publication_range = earliest_publication
+        else:
+            publication_range = earliest_publication + "-" + latest_publication
+        self.publication_range = publication_range
+        # update_fields avoids clobbering other (possibly stale) in-memory fields
+        # during what is nominally a read.
+        self.save(update_fields=['publication_range'])
+        return publication_range
 
     @property
     def has_unglued_edition(self):

--- a/core/tests.py
+++ b/core/tests.py
@@ -908,6 +908,47 @@ class WorkTests(TestCase):
         self.assertEqual(e2, self.w1.preferred_edition)
         self.assertEqual(e2, self.w2.preferred_edition)
 
+    def test_publication_date_no_editions(self):
+        self.assertEqual(self.w1.publication_date, '')
+
+    def test_publication_date_single_year(self):
+        models.Edition.objects.create(work=self.w1, publication_date='2007')
+        models.Edition.objects.create(work=self.w1, publication_date='2007-08-22')
+        self.assertEqual(self.w1.publication_date, '2007')
+
+    def test_publication_date_range(self):
+        models.Edition.objects.create(work=self.w1, publication_date='2007')
+        models.Edition.objects.create(work=self.w1, publication_date='2017-08-23')
+        self.assertEqual(self.w1.publication_date, '2007-2017')
+
+    def test_publication_date_ignores_blank_and_null(self):
+        # Regression for #1155: editions with NULL/blank publication_date pass the
+        # isnull=False filter (blank) or are simply absent (NULL) and must not
+        # produce a None "latest" year that crashes the range concatenation.
+        models.Edition.objects.create(work=self.w1, publication_date=None)
+        models.Edition.objects.create(work=self.w1, publication_date='')
+        models.Edition.objects.create(work=self.w1, publication_date='2007')
+        models.Edition.objects.create(work=self.w1, publication_date='2017')
+        # Must not raise TypeError, and blanks must not pollute the range.
+        self.assertEqual(self.w1.publication_date, '2007-2017')
+
+    def test_publication_date_only_blank_editions(self):
+        models.Edition.objects.create(work=self.w1, publication_date=None)
+        models.Edition.objects.create(work=self.w1, publication_date='')
+        self.assertEqual(self.w1.publication_date, '')
+
+    def test_publication_date_uses_single_edition_query(self):
+        # Regression for #1155: the uncached path must evaluate the editions once
+        # (1 SELECT) and persist the cache (1 UPDATE) -- not the old two-query
+        # (asc + desc) shape whose inconsistent reads caused the crash.
+        models.Edition.objects.create(work=self.w1, publication_date='2007')
+        models.Edition.objects.create(work=self.w1, publication_date='2017')
+        with self.assertNumQueries(2):
+            self.assertEqual(self.w1.publication_date, '2007-2017')
+        # Now cached: no further queries.
+        with self.assertNumQueries(0):
+            self.assertEqual(self.w1.publication_date, '2007-2017')
+
     def test_valid_subject(self):
         self.assertTrue(valid_subject(u'A, valid, suj\xc3t'))
         self.assertFalse(valid_subject(u'A, valid, suj\xc3t, '))


### PR DESCRIPTION
Fixes prod 500s #1155 (work-page TypeError, publication_date race) and #1156 (widget DoesNotExist on junk ids) — the pre-cutover hotfix release planned in the relaunch memo §6, approved by Eric in today's 10:00 meeting.

Promotes master (containing merged #1157, #1158) to production. Both fixes red→green tested on the 1.11 and 4.2 stacks; deployed and smoke-tested on test.unglue.it this morning (branch `test.unglue.it`).

Follows the release-PR pattern of #1134/#1150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)