### PR TITLE
Add set_site_domain management command (fix #1164)

### DIFF
--- a/core/management/commands/set_site_domain.py
+++ b/core/management/commands/set_site_domain.py
@@ -30,8 +30,24 @@ class Command(BaseCommand):
 
     def handle(self, domain, name, **options):
         site_id = settings.SITE_ID
-        site = Site.objects.get(pk=site_id)
         display_name = name if name else domain
+
+        # Use get_or_create so a fresh / scrubbed DB without a SITE_ID row is
+        # created correctly rather than hard-failing the deploy with
+        # Site.DoesNotExist (Codex review 2026-06-16).
+        site, created = Site.objects.get_or_create(
+            pk=site_id,
+            defaults={"domain": domain, "name": display_name},
+        )
+        if created:
+            Site.objects.clear_cache()
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Updated Site (pk={site_id}): created with "
+                    f"domain={site.domain!r}  name={site.name!r}"
+                )
+            )
+            return
 
         self.stdout.write(
             f"Current Site (pk={site_id}): domain={site.domain!r}  name={site.name!r}"

--- a/core/management/commands/set_site_domain.py
+++ b/core/management/commands/set_site_domain.py
@@ -1,0 +1,54 @@
+from django.contrib.sites.models import Site
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    """Localize the current Site row (SITE_ID) to this box's domain.
+
+    Useful after snapshot-restoring a staging box from prod: the DB will still
+    carry prod's Site row, causing emailed links (password-reset, notices, etc.)
+    to point at production.  Run this command as a post-deploy step to fix it.
+
+    Idempotent: if the Site row already matches the requested domain/name, it
+    prints a "no-op" message and exits cleanly without touching the DB.
+    """
+
+    help = "Update the current Site row (SITE_ID) to the given domain and name"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "domain",
+            help="Domain to set on the current Site row (e.g. dj42.unglue.it)",
+        )
+        parser.add_argument(
+            "name",
+            nargs="?",
+            default=None,
+            help="Display name to set on the Site row (defaults to domain if omitted)",
+        )
+
+    def handle(self, domain, name, **options):
+        site_id = settings.SITE_ID
+        site = Site.objects.get(pk=site_id)
+        display_name = name if name else domain
+
+        self.stdout.write(
+            f"Current Site (pk={site_id}): domain={site.domain!r}  name={site.name!r}"
+        )
+
+        if site.domain == domain and site.name == display_name:
+            self.stdout.write("Site row already matches requested values — no-op.")
+            return
+
+        site.domain = domain
+        site.name = display_name
+        site.save()
+        # Clear the Sites framework cache so the new value takes effect immediately.
+        Site.objects.clear_cache()
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Updated Site (pk={site_id}): domain={site.domain!r}  name={site.name!r}"
+            )
+        )


### PR DESCRIPTION
Fixes Gluejar/regluit#1164 — staging boxes inherit prod's Site row after snapshot restore, so emailed links (password-reset, notices, payment emails) point at unglue.it instead of the staging box's own host. This adds a management command to localize the Site to the box's own domain on deploy.

## What changed

- **`core/management/commands/set_site_domain.py`** — new management command.  
  Accepts a required `domain` positional arg and an optional `name` arg (defaults to `domain`).  
  Reads `settings.SITE_ID`, fetches the matching `Site` row, prints the before-state, and updates only if the value differs (idempotent).  Calls `Site.objects.clear_cache()` so the change is visible immediately without a restart.

## Why it's a no-op on prod

`server_name = "unglue.it"` on the production group.  `Site #1.domain` is already `"unglue.it"`, so the command prints "no-op" and returns without touching the DB.

## Why it's idempotent

Guard at the top: if `site.domain == domain and site.name == display_name`, bail out early with a message and no DB write.

## How it's wired up

The companion PR in EbookFoundation/regluit-provisioning adds a post-deploy `django_manage` task (after `migrate`) that calls `set_site_domain {{ server_name }}` via the existing `regluit_prod` role pattern.

## Test manually

```bash
# On a staging box (or locally with a test DB):
python manage.py set_site_domain dj42.unglue.it
# Re-run to verify idempotency:
python manage.py set_site_domain dj42.unglue.it
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)