### PR TITLE
FAQ copy: objective typo & grammar fixes (#1165)

### DIFF
--- a/frontend/templates/faq.html
+++ b/frontend/templates/faq.html
@@ -28,17 +28,17 @@
 
 <dd>The ebooks available on Unglue.it have missions to accomplish. There are textbooks to help you learn. There is literature to open up your mind. There are books on technology to help you create. There are academic books that are spreading ideas. There are books that want to change your mind. And there are books that belong to all of us, that want to live into the future.<br /><br />
 
-Freedom can help a book accomplish its mission, and that why the ebook is free. We call these books "unglued" and we call the process of making them free, "ungluing".</dd>
+Freedom can help a book accomplish its mission, and that's why the ebook is free. We call these books "unglued" and we call the process of making them free, "ungluing".</dd>
 
 
 <dt>So how do you make money?</dt>
 
-<dd>We don't - we're an non-profit. If you like what we do, <a href="{% url 'newdonation' %}">you can donate!</a></dd>
+<dd>We don't - we're a non-profit. If you like what we do, <a href="{% url 'newdonation' %}">you can donate!</a></dd>
 
 <dt>What about the authors and publishers, how do they make money?</dt>
 
 
-<dd>That's the million dollar question. You don't make money by giving away ebooks. Many authors make money other ways - by teaching, by consulting, by getting tenure. Some authors do well be selling printed books alongside their free ebooks. We started Unglue.it because we hoped to give ebook creators additional ways to support their work: <a href="{% url 'faq_location' 'campaigns' %}">Ungluing Campaigns</a>.
+<dd>That's the million dollar question. You don't make money by giving away ebooks. Many authors make money other ways - by teaching, by consulting, by getting tenure. Some authors do well by selling printed books alongside their free ebooks. We started Unglue.it because we hoped to give ebook creators additional ways to support their work: <a href="{% url 'faq_location' 'campaigns' %}">Ungluing Campaigns</a>.
 <br /><br />  We hope you'll choose to support some of these Campaigns, but if you like an ebook you find on Unglue.it, don't hesitate to lend  your support in other ways.
 </dd>
 
@@ -51,7 +51,7 @@ To support a Thanks-for-Ungluing campaign or make a donation, you'll need a vali
 
 <dt>Does Unglue.it own the copyright of unglued books?</dt>
 
-<dd>No.  Books available on unglue.it are licensed by the the copyright owner.  <a href="https://creativecommons.org">Creative Commons</a> licenses are licensing agreements.  They grant certain rights but do not affect the status of the copyright. You can read more about these licenses at the <a href="https://wiki.creativecommons.org/Frequently_Asked_Questions">Creative Commons FAQ</a>.</dd>
+<dd>No.  Books available on Unglue.it are licensed by the copyright owner.  <a href="https://creativecommons.org">Creative Commons</a> licenses are licensing agreements.  They grant certain rights but do not affect the status of the copyright. You can read more about these licenses at the <a href="https://wiki.creativecommons.org/Frequently_Asked_Questions">Creative Commons FAQ</a>.</dd>
 
 <dt>Does Unglue.it publish books?  Can I self-publish here?</dt>
 
@@ -62,7 +62,7 @@ To support a Thanks-for-Ungluing campaign or make a donation, you'll need a vali
 <dd>A rights holder is a person (or entity) that has a right to copy, distribute, or sell a book in some way.  There may be one entity with all the rights to a work, or the rights may be split up among different entities: for example, one who publishes the print edition in the United States, another who publishes the print edition in the EU, another who holds electronic rights, et cetera.  For ungluing purposes, the rights holder is the entity who has uncontested worldwide commercial rights to a work.<br /><br />
 If you have written a book and not signed any contracts about it, you hold all the rights.  If you have signed a contract with a publisher to produce, distribute, publish, or sell your work in a particular format or a particular territory, whether or not you still hold rights depends on the language of that contract.  We encourage you to check your contracts.  It may be in your interest to explore launching an Unglue.it campaign jointly with your publisher.<br /><br />
 If you haven't written a book but you have had business or family relationships with someone who has, it's possible that you are a rights holder (for instance, you may have inherited rights from the author's estate, or your company may have acquired them during a merger).  Again, this all depends on the specific language of your contracts.  We encourage you to read them closely.  Unglue.it cannot provide legal advice.<br /><br />
-If you believe you are a rights holder and would like us to help unglue your works, get started at <a href="{% url 'rightsholders' %}">the right holder tools page</a>.</dd>
+If you believe you are a rights holder and would like us to help unglue your works, get started at <a href="{% url 'rightsholders' %}">the rights holder tools page</a>.</dd>
 
 </dl>
 {% endif %}
@@ -75,7 +75,7 @@ Click on this <a href="{% url 'password_reset' %}">forgot your password</a> link
 </dd>
 <dt>I never received an activation email after I signed up, or my activation email isn't working. What do I do?</dt>
 
-<dd>Check your spam folder for mail from notices@gluejar.com.  If that doesn't work,  <a href="{% url 'feedback' %}?page=no+activation+email">Let us know!</a></dd>
+<dd>Check your spam folder for mail from notices@gluejar.com.  If that doesn't work,  <a href="{% url 'feedback' %}?page=no+activation+email">let us know!</a></dd>
 
 <dt>How can I change my profile name or password, or the email address associated with my account?</dt>
 
@@ -98,7 +98,7 @@ If you receive our newsletter, there's a link at the bottom of every message to 
 <dl>
 <dt>How can I contact Unglue.it?</dt>
 
-<dd>For support requests, <a href="{% url 'feedback' %}?page=need+support">use our feedback form</a>. You can also contact us on <a href="mailto:unglueit@ebookfoundation.org">email</a>,  <a href="https://digipres.club/@unglueit">Mastodon</a>  or <a href="https://facebook/com/unglueit">Facebook</a>.
+<dd>For support requests, <a href="{% url 'feedback' %}?page=need+support">use our feedback form</a>. You can also contact us on <a href="mailto:unglueit@ebookfoundation.org">email</a>,  <a href="https://digipres.club/@unglueit">Mastodon</a>  or <a href="https://facebook.com/unglueit">Facebook</a>.
 
 </dd>
 
@@ -115,7 +115,7 @@ If you receive our newsletter, there's a link at the bottom of every message to 
 <dl>
 <dt>How can I support free ebooks on Unglue.it?</dt>
 
-<dd>Unglue.it's active program is <i><a href="{% url 'faq_sublocation' 'campaigns' 't4u' %}">Thanks for Ungluing</a></i>. When a creator releases an ebook with a Creative Commons license, supporters can express their thanks by paying what they wish. You can also <a href="{% url 'newdonation' %}">make a donation</a> to the Free Ebook Foundation to support the site and its mission.
+<dd>Unglue.it's active program is <i><a href="{% url 'faq_sublocation' 'campaigns' 't4u' %}">Thanks-for-Ungluing</a></i>. When a creator releases an ebook with a Creative Commons license, supporters can express their thanks by paying what they wish. You can also <a href="{% url 'newdonation' %}">make a donation</a> to the Free Ebook Foundation to support the site and its mission.
 </dd>
 
 {% if sublocation == 'all' or sublocation == 't4u' %}
@@ -194,7 +194,7 @@ Under all CC licenses (except CC0), you <b>cannot</b>: remove the author's name 
 
 <dt>Unglue.it lists a book that I know is already Creative Commons licensed or available in the public domain. How can I get the link included?</dt>
 
-<dd>If you are logged in to Unglue.it, the "More..." tab for every work lists the editions we know about. There is a link for every edition that you can use to tell us about Creative Commons or public domain downloads.  We require that these books be hosted at certain known, reputable repositories such as Internet Archive, Wikisources, Hathi Trust, Project Gutenberg, Github or Google Books.</dd></dl>
+<dd>If you are logged in to Unglue.it, the "More..." tab for every work lists the editions we know about. There is a link for every edition that you can use to tell us about Creative Commons or public domain downloads.  We require that these books be hosted at certain known, reputable repositories such as Internet Archive, Wikisource, HathiTrust, Project Gutenberg, GitHub, or Google Books.</dd></dl>
 {% endif %}
 {% endif %}
 
@@ -207,10 +207,10 @@ Under all CC licenses (except CC0), you <b>cannot</b>: remove the author's name 
 
 <dd>To start a campaign, you need to be a verified rights holder who has signed a Rights Holder Agreement with us.  <br /><br />
 
-Start by visiting the <a href="{% url 'rightsholders' %}">Rights Holders Tools</a> page.You'll sign  our <a href="{% url 'agree' %}">Rights Holder Agreement (RHA)</a> and learn about our various programs.</dd>
+Start by visiting the <a href="{% url 'rightsholders' %}">Rights Holders Tools</a> page. You'll sign  our <a href="{% url 'agree' %}">Rights Holder Agreement (RHA)</a> and learn about our various programs.</dd>
 
 <dt>I haven't signed an agreement, but my books are listed on Unglue.it. What's going on?</dt>
-<dd>If your book is listed on Unglue.it, it's either because an unglue.it user has indicated some interested in the book, or it's because we've determined that your book is already available with a free license. 
+<dd>If your book is listed on Unglue.it, it's either because an Unglue.it user has indicated some interest in the book, or it's because we've determined that your book is already available with a free license. 
 </dd>
 
 <dt>Can I run more than one campaign?</dt>
@@ -297,7 +297,7 @@ If you want to find an interesting campaign and don't have a specific book in mi
 <dl>
 <dt>If I am an author with my book still in print, can I still start a campaign to unglue it?</dt>
 
-<dd>This depends entirely on your original contract with your publisher. You should seek independent advice about your royalty clauses and the "Subsidiary Rights" clauses of your contract. The Authors' Guild provides guidance for its members.</dd>
+<dd>This depends entirely on your original contract with your publisher. You should seek independent advice about your royalty clauses and the "Subsidiary Rights" clauses of your contract. The Authors Guild provides guidance for its members.</dd>
 
 <dt>If I am an author do I have to talk to my publisher or agent first?</dt>
 
@@ -313,11 +313,11 @@ If you want to find an interesting campaign and don't have a specific book in mi
 
 <dt>Can I offer a book to be unglued even if I cannot include all the illustrations from the print edition?</dt>
 
-<dd>Yes. If permission to reprint cannot not be obtained for items such as photographs, drawings, color plates, as well as quotations from lyrics and poetry, we can produce an unglued edition which leaves them out.  You must indicate the difference between the editions on your Campaign page.</dd>
+<dd>Yes. If permission to reprint cannot be obtained for items such as photographs, drawings, color plates, as well as quotations from lyrics and poetry, we can produce an unglued edition which leaves them out.  You must indicate the difference between the editions on your Campaign page.</dd>
 
 <dt>What impact does ungluing a book have on the rights status of my other editions?</dt>
 
-<dd>The Creative Commons licenses are non-exclusive.  They will apply only to the unglued edition, not to the print, audio, or any other editions. They does not affect the rights status of those other editions. If you use the no-derivative, noncommercial license (CC BY-NC-ND), no one else may sell your book or make derivatives unless you give them permission to do so.</dd>
+<dd>The Creative Commons licenses are non-exclusive.  They will apply only to the unglued edition, not to the print, audio, or any other editions. They do not affect the rights status of those other editions. If you use the NoDerivatives, NonCommercial license (CC BY-NC-ND), no one else may sell your book or make derivatives unless you give them permission to do so.</dd>
 
 <dt>Can an unglued ebook be issued only in the US?</dt>
 


### PR DESCRIPTION
Fixes part of Gluejar/regluit#1165 — **the safe, mechanical half** of the FAQ copy review. These are objective corrections (typos, a broken URL, proper nouns, subject-verb agreement, site-name casing) with **no meaning change, no factual claims, and no content removal** — intended to merge as-is.

Single file: `frontend/templates/faq.html` (14 edits).

### What changed
| Was | Now |
|-----|-----|
| "and **that why** the ebook is free" | "that's why" |
| "we're **an** non-profit" | "a non-profit" |
| "do well **be** selling" | "by selling" |
| "by **the the** copyright owner" | "the copyright owner" |
| "the **right holder** tools page" | "rights holder" |
| "indicated **some interested**" | "some interest" |
| "https://**facebook/com**/unglueit" | "facebook.com/unglueit" (broken URL) |
| "**Wikisources, Hathi Trust** … **Github**" | "Wikisource, HathiTrust … GitHub" |
| "page.**You'll**" | "page. You'll" (missing space) |
| mid-sentence "**Let** us know" | "let us know" |
| "**cannot not** be obtained" | "cannot be obtained" |
| "They **does** not affect" | "They do not affect" |
| "Authors**'** Guild" | "Authors Guild" |
| "no-derivative, noncommercial license" | "NoDerivatives, NonCommercial license" (CC styling) |
| site-name casing `unglue.it` → `Unglue.it`; "Thanks for Ungluing" → "Thanks-for-Ungluing" | consistency |

### Companion PR
The **judgment-call / factual** items from #1165 (fee-example math, payout terms, `notices@gluejar.com` sender, contact-email mismatch, whether Buy-to-Unglue / Pledge / Premiums campaigns are retired, Smashwords page, FEF-era framing) are in a **separate draft PR for Eric's review** — they change meaning or depend on facts only he can confirm.

Source: the consolidated CC + Codex two-reviewer findings on #1165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)