### PR TITLE
Fix libraryauth signals: move AppConfig to apps.py so ready() fires

### DIFF
--- a/libraryauth/__init__.py
+++ b/libraryauth/__init__.py
@@ -1,9 +1,3 @@
-from django.apps import AppConfig
-
-default_app_config = 'regluit.libraryauth.LibraryAuthConfig'
-
-class LibraryAuthConfig(AppConfig):
-    name = 'regluit.libraryauth'
-
-    def ready(self):
-        from . import signals
+# LibraryAuthConfig moved to libraryauth/apps.py (auto-discovered by Django).
+# Do NOT reintroduce `default_app_config` here — it was removed in Django 4.1
+# and an AppConfig defined in this __init__.py would never run its ready().

--- a/libraryauth/apps.py
+++ b/libraryauth/apps.py
@@ -1,0 +1,13 @@
+from django.apps import AppConfig
+
+
+class LibraryAuthConfig(AppConfig):
+    name = 'regluit.libraryauth'
+
+    def ready(self):
+        # Connect the user_activated receiver in signals.py.
+        # MUST live in apps.py: Django 4.1 removed `default_app_config`, so an
+        # AppConfig defined only in __init__.py is never discovered and ready()
+        # never runs. (That regression silently disabled this app's signals from
+        # the 2026-06-17 Django 4.2 cutover until this fix.)
+        from . import signals  # noqa: F401

--- a/libraryauth/tests.py
+++ b/libraryauth/tests.py
@@ -67,3 +67,28 @@ class TestLibraryAuth(TestCase):
         from .emailcheck import is_disposable
         self.assertFalse(is_disposable('eric@hellman.net'))
         self.assertTrue(is_disposable('eric@mailnesia.com'))
+
+
+class TestAppConfigSignalsWired(TestCase):
+    """Regression guard for issue #1175.
+
+    Django 4.1 removed `default_app_config`, and an AppConfig defined in an app's
+    __init__.py is NOT auto-discovered (Django only scans <app>/apps.py). When that
+    regression bit during the 4.2 cutover, LibraryAuthConfig.ready() stopped running
+    and signals.py was never imported. These tests fail if the config ever moves back
+    out of apps.py or otherwise stops being the active config.
+    """
+
+    def test_appconfig_is_discovered(self):
+        from django.apps import apps
+        from regluit.libraryauth.apps import LibraryAuthConfig
+        self.assertIsInstance(apps.get_app_config('libraryauth'), LibraryAuthConfig)
+
+    def test_user_activated_receiver_connected(self):
+        # ready() must have imported signals.py and connected the dedup receiver.
+        from django_registration.signals import user_activated
+        names = []
+        for _key, ref in user_activated.receivers:
+            fn = ref if getattr(ref, '__name__', None) else (ref() if callable(ref) else None)
+            names.append(getattr(fn, '__name__', None))
+        self.assertIn('handle_same_email_account', names)


### PR DESCRIPTION
Fixes #1175 — **why:** `libraryauth`'s `ready()` has not fired since the 2026-06-17 Django 4.2 cutover (Django 4.1 removed `default_app_config`; an AppConfig in `__init__.py` isn't auto-discovered), so its `user_activated` dedup signal has been silently disconnected in production.

## Change
- **Add `libraryauth/apps.py`** with `LibraryAuthConfig` (auto-discovered by Django) — `ready()` connects `signals.py`.
- **`libraryauth/__init__.py`**: remove the AppConfig + dead `default_app_config`; leave a comment so it isn't reintroduced.

Backward-compatible: valid on Django 4.2 (current prod) and 5.2 (the upcoming upgrade).

## Verification
- Minimal repro proves `ready()` fires with `apps.py` on **both 4.2.21 and 5.2.15** (and does NOT without it).
- Nothing imports `LibraryAuthConfig` from the package (safe move).
- ⬜ Pending: confirm on dj42 that `handle_same_email_account` is connected post-deploy + read-only impact count (never-activated dup-email accounts the handler will delete on activation).

## Deploy note
This is a code change → needs to reach the **deployed branch** and an **app restart** to take effect. Prod currently deploys `prod-green`, not `master`/`production` (deploy-branch repoint = #1170 step 3 still pending), so merging to master alone won't deploy it — route via the normal prod deploy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)