### PR TITLE
Release: libraryauth AppConfig fix → production (master → production) — refs #1170

### DIFF
--- a/libraryauth/__init__.py
+++ b/libraryauth/__init__.py
@@ -1,9 +1,3 @@
-from django.apps import AppConfig
-
-default_app_config = 'regluit.libraryauth.LibraryAuthConfig'
-
-class LibraryAuthConfig(AppConfig):
-    name = 'regluit.libraryauth'
-
-    def ready(self):
-        from . import signals
+# LibraryAuthConfig moved to libraryauth/apps.py (auto-discovered by Django).
+# Do NOT reintroduce `default_app_config` here — it was removed in Django 4.1
+# and an AppConfig defined in this __init__.py would never run its ready().

--- a/libraryauth/apps.py
+++ b/libraryauth/apps.py
@@ -1,0 +1,13 @@
+from django.apps import AppConfig
+
+
+class LibraryAuthConfig(AppConfig):
+    name = 'regluit.libraryauth'
+
+    def ready(self):
+        # Connect the user_activated receiver in signals.py.
+        # MUST live in apps.py: Django 4.1 removed `default_app_config`, so an
+        # AppConfig defined only in __init__.py is never discovered and ready()
+        # never runs. (That regression silently disabled this app's signals from
+        # the 2026-06-17 Django 4.2 cutover until this fix.)
+        from . import signals  # noqa: F401

--- a/libraryauth/tests.py
+++ b/libraryauth/tests.py
@@ -67,3 +67,28 @@ class TestLibraryAuth(TestCase):
         from .emailcheck import is_disposable
         self.assertFalse(is_disposable('eric@hellman.net'))
         self.assertTrue(is_disposable('eric@mailnesia.com'))
+
+
+class TestAppConfigSignalsWired(TestCase):
+    """Regression guard for issue #1175.
+
+    Django 4.1 removed `default_app_config`, and an AppConfig defined in an app's
+    __init__.py is NOT auto-discovered (Django only scans <app>/apps.py). When that
+    regression bit during the 4.2 cutover, LibraryAuthConfig.ready() stopped running
+    and signals.py was never imported. These tests fail if the config ever moves back
+    out of apps.py or otherwise stops being the active config.
+    """
+
+    def test_appconfig_is_discovered(self):
+        from django.apps import apps
+        from regluit.libraryauth.apps import LibraryAuthConfig
+        self.assertIsInstance(apps.get_app_config('libraryauth'), LibraryAuthConfig)
+
+    def test_user_activated_receiver_connected(self):
+        # ready() must have imported signals.py and connected the dedup receiver.
+        from django_registration.signals import user_activated
+        names = []
+        for _key, ref in user_activated.receivers:
+            fn = ref if getattr(ref, '__name__', None) else (ref() if callable(ref) else None)
+            names.append(getattr(fn, '__name__', None))
+        self.assertIn('handle_same_email_account', names)


### PR DESCRIPTION
Refs #1170 — **bring `production` current with the deployed reality.** `production` is the only canonical branch still out of sync: it is missing the libraryauth AppConfig hotfix (#1175/#1176) that is already on `master` **and already live on the green box** (`prod-green @ 04b85058`, verified on the box 2026-06-19 — `libraryauth/apps.py` present, `ready()` fires).

> ## 📒 TL;DR — accounting PR, completes the #1170 production-side sync
> - Carries exactly **3 commits**: the libraryauth `apps.py` fix + its regression test + the merge (#1176).
> - After merge, **`production` tree == `master` tree == the running green box tree** (`e8f716d6`) — verified byte-identical.
> - **Zero live-site impact** — prod deploys `prod-green` via manual Ansible; nothing auto-deploys on `production`. This updates the ledger only.

### Why now
The earlier release #1169 aligned `production` with the 4.2 upgrade, but it merged *before* the libraryauth hotfix landed on `master`. So `production` regressed behind `master` by those 3 commits. Until this PR merges, repointing the deploy branch to `production` (the next #1170 step) would **roll back the libraryauth fix** on prod. This closes that trap.

### State (verified 2026-06-19)
- `production` vs `master`: **3 ahead / 9 behind**. The 9 "behind" commits are the same release-merge plumbing #1169 documented (May DOAB-429 / bitstream / pyoai releases) — content already in `master` under different SHAs, benign dupes.
- Tree equivalence: `master` tree `e8f716d6` == live `prod-green` tree `e8f716d6`; `production` tree `a80b254c` (behind only by libraryauth).

### Safety / reversibility
- No auto-deploy on `production`; merging does not touch the running site.
- The only live-affecting step is the **deploy-branch repoint** (`prod-green → production` + re-provision green) — a **separate** follow-up in #1170, to run with Eric in a low-traffic window, verifying `deployed SHA == production tip` on the box.
- Reversible (reset / `git revert -m 1`).

### Sequence
Use a **merge commit** (preserve lineage), not squash. Merge is Eric's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
