### PR TITLE
Fix /lists/recommended 500: use __in for QuerySet-valued lookup (fixes #1179)

### DIFF
--- a/frontend/views/__init__.py
+++ b/frontend/views/__init__.py
@@ -646,7 +646,7 @@ class WorkListView(FilterableListView):
             return models.Work.objects.exclude(num_wishes=0).order_by('-num_wishes')
         elif facet == 'recommended':
             self.template_name = "recommended.html"
-            return models.Work.objects.filter(wishlists__user=recommended_user).order_by('-num_wishes')
+            return models.Work.objects.filter(wishlists__user__in=recommended_user).order_by('-num_wishes')
         else:
             return models.Work.objects.all().order_by('-created')
 


### PR DESCRIPTION
Fixes #1179 — `/lists/recommended` has returned **HTTP 500 since the 1.11→4.2 cutover** because a QuerySet was passed to an exact related lookup.

### Why
`recommended_user` (`frontend/views/__init__.py:637`) is a **QuerySet** (`User.objects.filter(username='unglueit')`). Line 649 used it in an *exact* lookup `wishlists__user=recommended_user`, which Django 4.x rejects:
> ValueError: The QuerySet value for an exact lookup must be limited to one result using slicing.

Django 1.11 tolerated this, so the endpoint broke at the cutover and has been 500ing in prod since 2026-06-17.

### Fix (one line)
```diff
-            return models.Work.objects.filter(wishlists__user=recommended_user).order_by('-num_wishes')
+            return models.Work.objects.filter(wishlists__user__in=recommended_user).order_by('-num_wishes')
```
- Behavior-preserving (`username` unique → 0/1 user); degrades gracefully (empty list, not 500) if `unglueit` is absent.
- Valid on **both** Django 4.2 and 5.2 (so it rides forward to the 5.2 branch via the next `master` merge).

### Review
Independently reviewed by **Codex → LGTM**: diagnosis correct, `__in` with a QuerySet is supported on 4.2/5.2, no new duplicate-row risk, and module-level `.get()`/`.first()` correctly avoided (import-time DB access / wrong None semantics).

### Follow-up (deferred, not in this hotfix)
Codex's cleaner form inlines the lookup and drops the module-level query:
`wishlists__user__username=settings.UNGLUEIT_RECOMMENDED_USERNAME`. Left out to keep the hotfix surgical.

### Verification
After deploy: `curl -s -o /dev/null -w '%{http_code}' https://unglue.it/lists/recommended` → expect **200** (currently 500).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
