### PR TITLE
Fix /accounts/register/ 500: read cleaned_data['email'] (django-registration 3.x) — fixes #1182

### DIFF
--- a/libraryauth/forms.py
+++ b/libraryauth/forms.py
@@ -113,7 +113,11 @@ class RegistrationFormNoDisposableEmail(RegistrationFormUniqueEmail, UserNamePas
         Check the supplied email address against a list of known disposable
         webmail domains.
         """
-        cleaned_email = super(RegistrationFormNoDisposableEmail, self).clean_email()
+        # django-registration 3.x moved the unique-email check to a field validator
+        # (RegistrationFormUniqueEmail.__init__), so there is no super().clean_email()
+        # to call any more. By the time this per-field clean runs, the email field has
+        # already been validated and stored in cleaned_data.
+        cleaned_email = self.cleaned_data['email']
         logger.info('cleaning email')
         if is_disposable(cleaned_email):
             raise forms.ValidationError(_("Please supply a permanent email address."))


### PR DESCRIPTION
Fixes #1182 — **new-user registration has been fully down since the 1.11→4.2 cutover.** `POST /accounts/register/` 500s with `AttributeError: 'super' object has no attribute 'clean_email'`.

### Why
`RegistrationFormNoDisposableEmail.clean_email` calls `super().clean_email()`, but **django-registration 3.4** removed `clean_email` from `RegistrationForm`/`RegistrationFormUniqueEmail` — the unique-email check is now a field validator added in `__init__`. (The cutover bumped django-registration 2.x→3.4.)

### Fix (one line)
```diff
-        cleaned_email = super(RegistrationFormNoDisposableEmail, self).clean_email()
+        cleaned_email = self.cleaned_data['email']
```
Django's `_clean_fields` populates `cleaned_data['email']` (running the unique + confusable + email validators) **before** calling `clean_email()`, so uniqueness is still enforced and the disposable-domain check runs on the validated value. If the field errors, `clean_email()` is skipped → no `KeyError`.

### Review
**Codex → LGTM**: diagnosis correct, Django's validation order guarantees `cleaned_data['email']` is set before `clean_email`, no KeyError path. Caveat (for the 5.2 effort, not this hotfix): django-registration 3.4 is officially supported only through Django 4.2 — cover the registration flow in the 5.2 test suite.

### Verification
After deploy: a `POST /accounts/register/` returns a normal validation/redirect response instead of 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
