### PR TITLE
frontend/forms: stop 500s on invalid input (MsgForm, EbookForm) — refs #1185

### DIFF
--- a/frontend/forms/__init__.py
+++ b/frontend/forms/__init__.py
@@ -129,8 +129,10 @@ class EbookForm(forms.ModelForm):
         return new_label if new_label else self.cleaned_data['version_label']
 
     def set_provider(self):
-        url = self.cleaned_data['url']
-        new_provider = Ebook.infer_provider(url)
+        # clean_url() removes 'url' from cleaned_data when it raises (e.g. duplicate
+        # URL); guard so the form-level clean() reports that error instead of 500ing.
+        url = self.cleaned_data.get('url')
+        new_provider = Ebook.infer_provider(url) if url else None
         if url and not new_provider:
             raise forms.ValidationError(_("At this time, ebook URLs must point at Internet Archive, Wikisources, Wikibooks, Hathitrust, Project Gutenberg, raw files at Github, Google Books, or OApen."))
         self.cleaned_data['provider'] = new_provider if new_provider else "Unglue.it"
@@ -499,20 +501,24 @@ class MsgForm(forms.Form):
 
     def full_clean(self):
         super(MsgForm, self).full_clean()
+        # Use add_error(), not raise: a ValidationError raised from an overridden
+        # full_clean() propagates out of is_valid() (a 500) instead of marking the
+        # form invalid. Also catch ValueError/TypeError so a non-numeric id from POST
+        # doesn't crash the int lookup.
         if "supporter" in self.data:
             try:
                 self.cleaned_data['supporter'] = User.objects.get(id=self.data["supporter"])
-            except User.DoesNotExist:
-                raise ValidationError("Supporter does not exist")
+            except (User.DoesNotExist, ValueError, TypeError):
+                self.add_error(None, "Supporter does not exist")
         else:
-            raise ValidationError("Supporter is not specified")
+            self.add_error(None, "Supporter is not specified")
         if "work" in self.data:
             try:
                 self.cleaned_data['work'] = Work.objects.get(id=self.data["work"])
-            except Work.DoesNotExist:
-                raise ValidationError("Work does not exist")
+            except (Work.DoesNotExist, ValueError, TypeError):
+                self.add_error(None, "Work does not exist")
         else:
-            raise ValidationError("Work is not specified")
+            self.add_error(None, "Work is not specified")
 
 class PressForm(forms.ModelForm):
     class Meta:


### PR DESCRIPTION
Refs #1185 (A1, A2). Stops two `500`s on invalid form input.

**A1 — `MsgForm.full_clean`** ("message a supporter" POST, `frontend/views`:1722): two compounding bugs — (1) bare `ValidationError`, which is **not imported** in this module → `NameError`; (2) it `raise`d from an *overridden* `full_clean()`, which **propagates out of `is_valid()` as a 500** even with a proper `ValidationError` (verified empirically). Fixed with `self.add_error(None, ...)` (form is marked invalid cleanly) and by catching `ValueError/TypeError` so a non-numeric id from POST doesn't crash the int lookup.

**A2 — `EbookForm.set_provider`**: read `cleaned_data['url']` unconditionally; when `clean_url()` raises (duplicate URL) that key is removed → `KeyError` → 500. Use `.get('url')` and skip provider inference when url is absent.

**Codex: LGTM** — `add_error(None, ...)` creates non-field errors without escaping `is_valid()`; the `.get('url')` guard preserves valid/empty-url behavior. Behavior-preserving; valid on Django 4.2 and 5.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
