### PR TITLE
Release: post-cutover sweep fixes (tasks .get(), MsgForm, EbookForm) — refs #1185

### DIFF
--- a/core/tasks.py
+++ b/core/tasks.py
@@ -138,7 +138,7 @@ def notify_ending_soon():
 @task
 def watermark_acq(acq_id):
     try:
-        acq = Acq.objects.get(acq_id)
+        acq = Acq.objects.get(id=acq_id)
     except Acq.DoesNotExist as e:
         logger.error("error getting acq %s", acq_id)
         return False
@@ -147,7 +147,7 @@ def watermark_acq(acq_id):
 @task
 def process_ebfs(campaign_id):
     try:
-        campaign = Campaign.objects.get(campaign_id)
+        campaign = Campaign.objects.get(id=campaign_id)
     except Campaign.DoesNotExist as e:
         logger.error("error getting acq %s", campaign_id)
         return False
@@ -186,7 +186,7 @@ def refresh_acqs():
 @task
 def ml_subscribe_task(profile_id, **kwargs):
     try:
-        profile = UserProfile.objects.get(profile_id)
+        profile = UserProfile.objects.get(id=profile_id)
     except UserProfile.DoesNotExist as e:
         logger.error("error getting profile %s", profile_id)
         return False

--- a/frontend/forms/__init__.py
+++ b/frontend/forms/__init__.py
@@ -129,8 +129,10 @@ class EbookForm(forms.ModelForm):
         return new_label if new_label else self.cleaned_data['version_label']
 
     def set_provider(self):
-        url = self.cleaned_data['url']
-        new_provider = Ebook.infer_provider(url)
+        # clean_url() removes 'url' from cleaned_data when it raises (e.g. duplicate
+        # URL); guard so the form-level clean() reports that error instead of 500ing.
+        url = self.cleaned_data.get('url')
+        new_provider = Ebook.infer_provider(url) if url else None
         if url and not new_provider:
             raise forms.ValidationError(_("At this time, ebook URLs must point at Internet Archive, Wikisources, Wikibooks, Hathitrust, Project Gutenberg, raw files at Github, Google Books, or OApen."))
         self.cleaned_data['provider'] = new_provider if new_provider else "Unglue.it"
@@ -499,20 +501,24 @@ class MsgForm(forms.Form):
 
     def full_clean(self):
         super(MsgForm, self).full_clean()
+        # Use add_error(), not raise: a ValidationError raised from an overridden
+        # full_clean() propagates out of is_valid() (a 500) instead of marking the
+        # form invalid. Also catch ValueError/TypeError so a non-numeric id from POST
+        # doesn't crash the int lookup.
         if "supporter" in self.data:
             try:
                 self.cleaned_data['supporter'] = User.objects.get(id=self.data["supporter"])
-            except User.DoesNotExist:
-                raise ValidationError("Supporter does not exist")
+            except (User.DoesNotExist, ValueError, TypeError):
+                self.add_error(None, "Supporter does not exist")
         else:
-            raise ValidationError("Supporter is not specified")
+            self.add_error(None, "Supporter is not specified")
         if "work" in self.data:
             try:
                 self.cleaned_data['work'] = Work.objects.get(id=self.data["work"])
-            except Work.DoesNotExist:
-                raise ValidationError("Work does not exist")
+            except (Work.DoesNotExist, ValueError, TypeError):
+                self.add_error(None, "Work does not exist")
         else:
-            raise ValidationError("Work is not specified")
+            self.add_error(None, "Work is not specified")
 
 class PressForm(forms.ModelForm):
     class Meta:


### PR DESCRIPTION
Release `master → production`: ships the post-cutover sweep fixes (#1185) — #1186 (`core/tasks.py` positional `.get()`) and #1187 (`MsgForm`/`EbookForm` 500 guards).

Validated on **test.unglue.it** (master `3aaafb54`): `get(id=)` works for all 3 models; `MsgForm` returns invalid cleanly (no NameError/propagation); `EbookForm.set_provider` no longer KeyErrors. Codex-LGTM on both.

After merge: `ansible-playbook -i hosts deploy.yml` → re-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
