### PR TITLE
Fix registration 500: add missing django_registration/activation_email_body.txt (#1190)

### DIFF
--- a/frontend/templates/django_registration/activation_email_body.txt
+++ b/frontend/templates/django_registration/activation_email_body.txt
@@ -1,0 +1,1 @@
+{% include "registration/activation_email.txt" %}


### PR DESCRIPTION
Fixes #1190 — new-user registration has 500'd since the Jun 17 cutover.

django-registration 3.4's activation backend renders `django_registration/activation_email_body.txt`, but cutover commit `ce1faa4a` created the body wrapper under the old name `activation_email.txt` (the subject wrapper was named correctly). So the body never resolved → `TemplateDoesNotExist` → 500 on every registration POST.

This adds the body wrapper, mirroring the working subject wrapper and reusing the intact `registration/activation_email.txt`:
```django
{% include "registration/activation_email.txt" %}
```

Validation: reproduce the 500 on test.unglue.it, deploy, complete a real registration there, then promote to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)