### PR TITLE
Mask STRIPE_SK / EMAIL_HOST_USER in error-report settings dumps

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -16,6 +16,10 @@ PROJECT_DIR = dirname(dirname(realpath(__file__)))
 # Django 3.2+: preserve existing auto-field behavior for legacy models
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
+# Mask secrets the default filter misses (STRIPE_SK, EMAIL_HOST_USER, ...) in the
+# settings dump emailed on every 500. See EbookFoundation/security-private#22.
+DEFAULT_EXCEPTION_REPORTER_FILTER = 'regluit.utils.exception_filter.RegluitSafeExceptionReporterFilter'
+
 # Django 4.x defaults to JSONSerializer; make this explicit so existing sessions
 # aren't broken during the upgrade. Flush sessions during production cutover.
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'

--- a/utils/exception_filter.py
+++ b/utils/exception_filter.py
@@ -1,0 +1,18 @@
+"""Custom exception-report filter that masks secrets Django's default misses.
+
+Django's SafeExceptionReporterFilter cleanses setting names matching
+API|TOKEN|KEY|SECRET|PASS|SIGNATURE. That lets a few real secrets through in
+the settings dump emailed on every 500 — notably STRIPE_SK (live Stripe secret)
+and EMAIL_HOST_USER (SES SMTP username / AWS access-key id). Broaden the pattern.
+See EbookFoundation/security-private#22.
+"""
+import re
+
+from django.views.debug import SafeExceptionReporterFilter
+
+
+class RegluitSafeExceptionReporterFilter(SafeExceptionReporterFilter):
+    hidden_settings = re.compile(
+        "API|TOKEN|KEY|SECRET|PASS|SIGNATURE|STRIPE|EMAIL_HOST_USER|SMTP|CREDENTIAL",
+        flags=re.I,
+    )


### PR DESCRIPTION
Django's default `SafeExceptionReporterFilter` cleanses setting names matching `API|TOKEN|KEY|SECRET|PASS|SIGNATURE`, which lets a few real secrets through in the settings dump emailed on every 500 — notably `STRIPE_SK` (live Stripe secret) and `EMAIL_HOST_USER` (SES SMTP username / AWS access-key id).

Adds `regluit.utils.exception_filter.RegluitSafeExceptionReporterFilter` broadening the cleanse pattern, wired via `DEFAULT_EXCEPTION_REPORTER_FILTER` in `common.py` (inherited by all envs incl. prod). Regex verified to mask the secrets and leave ordinary settings (DEBUG, DATABASES, EMAIL_HOST, …) visible.

Security follow-up to the Stripe-key leak (private tracker). Validate on test.unglue.it (trigger a 500, confirm STRIPE_SK shows masked), then prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)