### PR TITLE
Fix make_cover_thumbnail: unconditional error log spamming celery logs

### DIFF
--- a/core/tasks.py
+++ b/core/tasks.py
@@ -231,5 +231,6 @@ def feature_new_work():
 @task
 def make_cover_thumbnail(url, geom_string, **options):
     success = covers.make_cover_thumbnail(url, geom_string, **options)
-    logger.error('bad cover image %s: %s', url)
+    if not success:
+        logger.error('bad cover image %s: %s', url, geom_string)
     


### PR DESCRIPTION
Found while investigating why \`/var/log/celery/w1.log\` had grown to ~800MB on prod.

## Two bugs, both from 03e71be2d (2024-10-28, 18+ months ago)
1. **Missing \`if not success:\` guard** — logged an ERROR on *every* cover-thumbnail attempt, success or failure.
2. **Format string mismatch** — two \`%s\` placeholders, only one arg (\`url\`) ever passed, so Python's own logging module threw \`TypeError: not enough arguments for format string\` on every single call — a \`--- Logging error ---\` traceback cascade instead of the intended error message.

Confirmed via \`git blame\` (exact commit/date) and live log inspection: **93,914+ occurrences in just the last few days alone** — almost certainly the single largest contributor to that log's size.

## Fix
```python
@task
def make_cover_thumbnail(url, geom_string, **options):
    success = covers.make_cover_thumbnail(url, geom_string, **options)
    if not success:
        logger.error('bad cover image %s: %s', url, geom_string)
```

## Codex review: LGTM
> `covers.make_cover_thumbnail` returns only `True` or `False`, so `if not success:` is correct.

## Test plan
- [ ] Deploy, monitor `w1.log` growth rate drops substantially
- [ ] Confirm real cover-image failures still log (with both url and geom_string now, not just url)