### PR TITLE
Release to production: make_cover_thumbnail logging fix (#1198)

### DIFF
--- a/core/tasks.py
+++ b/core/tasks.py
@@ -231,5 +231,6 @@ def feature_new_work():
 @task
 def make_cover_thumbnail(url, geom_string, **options):
     success = covers.make_cover_thumbnail(url, geom_string, **options)
-    logger.error('bad cover image %s: %s', url)
+    if not success:
+        logger.error('bad cover image %s: %s', url, geom_string)
     


### PR DESCRIPTION
Release PR: master → production.

Contains #1198 only:
- Fix `make_cover_thumbnail`'s unconditional error logging + broken format string (root cause of a celery worker log growing to ~800MB). Codex-reviewed, RY-approved, deployed and verified on test.unglue.it.

No other changes pending between production and master at this time.