### PR TITLE
Django 5.2 prep: STORAGES dict + drop USE_L10N (#1081)

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -41,9 +41,8 @@ SITE_ID = 1
 # to load the internationalization machinery.
 USE_I18N = True
 
-# If you set this to False, Django will not format dates, numbers and
-# calendars according to the current locale
-USE_L10N = True
+# USE_L10N was removed in Django 5.0 (localized formatting is always on), so it
+# is intentionally not set here.
 
 # Absolute filesystem path to the directory that will hold user-uploaded files.
 # Example: "/home/media/media.lawrence.com/media/"
@@ -542,10 +541,18 @@ except ImportError:
     TEST_INTEGRATION = False
     LOCAL_TEST = True
 
+# DEFAULT_FILE_STORAGE / STATICFILES_STORAGE were removed in Django 5.1 in favor of
+# the STORAGES dict. STORAGES is available since Django 4.2, so this is forward-
+# compatible and behaves identically on the current 4.2 runtime.
 if AWS_SECRET_ACCESS_KEY:
-    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+    _default_file_backend = 'storages.backends.s3boto3.S3Boto3Storage'
 else:
-    DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage' 
+    _default_file_backend = 'django.core.files.storage.FileSystemStorage'
+
+STORAGES = {
+    'default': {'BACKEND': _default_file_backend},
+    'staticfiles': {'BACKEND': 'django.contrib.staticfiles.storage.StaticFilesStorage'},
+}
 
 # we wond't record downloads for an ebook if their more than this in a month
 DOWNLOAD_LOGS_MAX = 499


### PR DESCRIPTION
First concrete step toward the Django 4.2 → 5.2 LTS upgrade ([#1081](https://github.com/Gluejar/regluit/issues/1081)). **Forward-compatible** settings changes that behave identically on the current 4.2 runtime and remove two 5.x landmines.

## Changes
- **`STORAGES` dict** replaces `DEFAULT_FILE_STORAGE` (removed in Django 5.1). `STORAGES` is supported since **4.2**, so this is a no-op on the live runtime; the S3 (`django-storages`) vs `FileSystemStorage` selection is preserved.
- **Drop `USE_L10N`** (removed in Django 5.0; localized formatting is always on).

## Why it's small
The other landmines from `PLAN_django52_upgrade.md` are already clean here: no `django.utils.timezone.utc`, no `index_together`, no removed util imports (`force_text`/`ugettext`/…). The real remaining work is the dependency audit (`django-selectable`, `django-registration`, ckeditor5) — separate PRs.

## ⚠️ Validation needed before merge
The `STORAGES` change touches the **prod S3 media path**. Confirm media upload + serve on **test.unglue.it** before merging (per the plan's "test, don't just rename").

No code reads `settings.DEFAULT_FILE_STORAGE` directly (checked), and no `STATICFILES_STORAGE` was set, so static handling is unchanged.