### PR TITLE
Django 4.2 → 5.2 LTS upgrade (#1081)

### DIFF
--- a/booxtream/tests.py
+++ b/booxtream/tests.py
@@ -61,7 +61,7 @@ class TestBooXtream(unittest.TestCase):
             }
         params['referenceid'] = 'order' + str(time.time())
         boox = inst.platform(epubfile=self.epub2file, **params)
-        self.assertRegexpMatches(boox.download_link_epub, 'download.booxtream.com/')
+        self.assertRegex(boox.download_link_epub, 'download.booxtream.com/')
         self.assertFalse(boox.expired)
         self.assertEqual(boox.downloads_remaining, 3)
 
@@ -71,4 +71,4 @@ class TestBooXtream(unittest.TestCase):
         in_mem_epub.write(self.epub2file.read())
         in_mem_epub.seek(0)
         boox2 = inst.platform(epubfile=in_mem_epub, **params)
-        self.assertRegexpMatches(boox2.download_link_epub, 'download.booxtream.com/')
+        self.assertRegex(boox2.download_link_epub, 'download.booxtream.com/')

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -422,8 +422,12 @@ class Campaign(models.Model):
             self.created = None
             self.name = 'copy of %s' % self.name
             self.activated = None
-            self.update_left()
+            # save() BEFORE update_left(): update_left() -> current_total filters
+            # Transactions on this instance, and Django 5.x raises ValueError for
+            # unsaved instances in related filters (4.2 silently matched nothing).
+            # A fresh clone has no transactions, so the computed totals are identical.
             self.save()
+            self.update_left()
             self.managers.set(old_managers)
 
             # clone associated premiums

--- a/core/tests.py
+++ b/core/tests.py
@@ -1099,8 +1099,8 @@ class EbookFileTests(TestCase):
         self.assertIsNot(acq.nonce, None)
 
         url = acq.get_watermarked().download_link_epub
-        self.assertRegexpMatches(url, 'github.com/eshellman/42_ebook/blob/master/download/42')
-        #self.assertRegexpMatches(url, 'booxtream.com/')
+        self.assertRegex(url, 'github.com/eshellman/42_ebook/blob/master/download/42')
+        #self.assertRegex(url, 'booxtream.com/')
 
         with self.assertRaises(UnglueitError) as cm:
             c.activate()

--- a/libraryauth/tests.py
+++ b/libraryauth/tests.py
@@ -88,7 +88,9 @@ class TestAppConfigSignalsWired(TestCase):
         # ready() must have imported signals.py and connected the dedup receiver.
         from django_registration.signals import user_activated
         names = []
-        for _key, ref in user_activated.receivers:
+        for entry in user_activated.receivers:
+            # Django <5.0: (lookup_key, receiver); Django >=5.0: (lookup_key, receiver, is_async)
+            ref = entry[1]
             fn = ref if getattr(ref, '__name__', None) else (ref() if callable(ref) else None)
             names.append(getattr(fn, '__name__', None))
         self.assertIn('handle_same_email_account', names)

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ cryptography==41.0.7; python_version >= '3.7'
 cssselect2==0.7.0; python_version >= '3.7'
 defusedxml==0.8.0rc2; python_version >= '3.6'
 distlib==0.3.8
-django==4.2.21
+django==5.2.15
 django-ckeditor==6.7.3
 nh3==0.3.6  # server-side HTML sanitization of CKEditor rich text (security-private#26)
 django-el-pagination==4.1.2
@@ -29,10 +29,10 @@ django-el-pagination==4.1.2
 django-extensions==3.1.1; python_version >= '3.6'
 django-js-asset==2.2.0
 # django-jsonfield removed — using Django 3.2+ native models.JSONField
-django-mptt==0.14.0
+django-mptt==0.18.0
 -e git+https://github.com/Gluejar/django-notification.git@2a7c138#egg=django-notification
 django-registration==3.4
-django-sass-processor==0.8.2
+django-sass-processor==1.4.2
 django-selectable==1.5.0
 django-storages==1.14.6
 docopt==0.6.2

--- a/settings/common.py
+++ b/settings/common.py
@@ -44,6 +44,13 @@ USE_I18N = True
 # USE_L10N was removed in Django 5.0 (localized formatting is always on), so it
 # is intentionally not set here.
 
+# Django 5.0 flipped the USE_TZ default from False to True. This codebase (and
+# the production database contents) use naive local datetimes throughout, so we
+# pin the pre-5.0 behavior. Migrating to timezone-aware datetimes is a separate
+# project (data migration + audit of every datetime comparison), not part of the
+# 4.2 -> 5.2 upgrade.
+USE_TZ = False
+
 # Absolute filesystem path to the directory that will hold user-uploaded files.
 # Example: "/home/media/media.lawrence.com/media/"
 MEDIA_ROOT = ''


### PR DESCRIPTION
[#1081](https://github.com/Gluejar/regluit/issues/1081) — the Django 5.2 LTS upgrade, **rebased 2026-08-23 onto post-comments-removal master** (`4a0a51b0`). Six files, +22/−9. Eric green-lit reviewing this 2026-08-10; **merge to master still gated on staging soak + Eric's look.**

## What changed in the rebase (vs the original spike you may have read)

- **`django-contrib-comments` bump is GONE** — the app was removed entirely by #1217/#1220, both live on production 2026-08-23. The `django_comments.0004` migration vanishes from this upgrade's path. That was the point of sequencing comments first.
- The #1202 STORAGES/USE_L10N prep is already on master — no longer a co-requisite.
- Everything else is the reviewed spike verbatim (confirmed by range-diff in Codex's re-review).

## The two judgment calls, unchanged

- **`USE_TZ = False` pinned**: Django 5.0 flipped the default; this codebase and its data are naive-datetime throughout. TZ-awareness is a separate project.
- **`Campaign.clone()` reorder**: 5.x raises on filtering related objects of unsaved instances. On the post-#1213 base this is lower-risk still — only THANKS campaigns are clonable, and THANKS `update_left()` sets `left=0` without querying transactions.

## Verification (2026-08-23, local MySQL 8, both spike envs on the identical tree)

- core + 16 scrub tests under 5.2.15: failure set **identical** to the 4.2 baseline (known offline/live-API failures only, zero new)
- frontend / payment / libraryauth: no new failures. (Two libraryauth errors that vary between versions in full-suite order are a pre-existing import-order fragility in `puzzle.py` cache snapshotting — they error under **both** versions in isolation; not upgrade evidence.)
- `migrate --plan` against a current-production-schema DB: **no pending migrations**
- Codex re-review of the rebased diff (2026-08-23): **LGTM for staging**; production waits for soak + Eric

## Soak plan

Staging (test.unglue.it = exact prod copy, same code+data shape as production as of today) gets this branch with `run_pip=true run_collectstatic=true`, then: Django-version-in-venv check, cold-start registration path, THANKS-only campaign smoke tests, historical-notification rendering, sass/storage pages, and log watch for naive/aware datetime and pickle errors. Prod deploy only after a clean multi-day soak and Eric's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGNAvPnAPCuS2vFAg6AiBB