### PR TITLE
OPDS: slice works in SQL, not islice — stop materializing the whole catalog (#1189)

### DIFF
--- a/api/opds.py
+++ b/api/opds.py
@@ -1,5 +1,4 @@
 import datetime
-from itertools import islice
 import logging
 from urllib.parse import urlparse, urlunparse
 
@@ -365,7 +364,11 @@ def opds_feed_for_works(the_facet, page=None, order_by='newest'):
                               None, order_by, group=other_group.title,
                               title=facet_object.title).prettify()
 
-    works = islice(works, 10 * page, 10 * page + 10)
+    # SQL-side slice (LIMIT/OFFSET). itertools.islice looked lazy but iterating
+    # a QuerySet runs _fetch_all(): every free work in the catalog (292k+) was
+    # materialized to serve 10 — ~360 MB per request, the memory high-water
+    # behind #1078/#1189 under OPDS crawler traffic.
+    works = works[10 * page:10 * page + 10]
     if page > 0:
         yield navlink('previous', feed_path, page-1, order_by, title="Previous 10").prettify()
 

--- a/api/opds_json.py
+++ b/api/opds_json.py
@@ -1,5 +1,4 @@
 import datetime
-from itertools import islice
 import logging
 import json
 
@@ -279,7 +278,8 @@ def opds_feed_for_works(the_facet, page=None, order_by='newest'):
                 group=other_group.title, title=facet_object.title
             )
 
-    works = islice(works, books_per_page * page, books_per_page * page + books_per_page)
+    # SQL-side slice (LIMIT/OFFSET), not islice — see api/opds.py / #1189.
+    works = works[books_per_page * page:books_per_page * page + books_per_page]
     if page > 0:
         append_navlink(links, 'previous', feed_path, page-1, order_by,
                        title="Previous {}".format(books_per_page))


### PR DESCRIPTION
Fixes the root cause identified in [#1189](https://github.com/Gluejar/regluit/issues/1189) (full investigation written up [in the issue](https://github.com/Gluejar/regluit/issues/1189#issuecomment-4895872568)) — the memory high-water behind the [#1078](https://github.com/Gluejar/regluit/issues/1078) OOM.

## The bug
OPDS acquisition feeds paged with `itertools.islice(works, ...)`. islice looks lazy, but iterating a Django QuerySet triggers `_fetch_all()`: **every free work in the catalog (292,403 rows) was materialized as a full Work object to serve a 10-item page.**

## Measurements (test.unglue.it, prod-twin data)
- One request to `/api/opds/all/?order_by=newest&page=3`: 51 KB response, **362 MB Python peak, +442 MB permanent worker RSS**
- Isolated A/B on the same ordered queryset: islice **359.3 MB** peak vs SQL slice **0.3 MB** peak — identical 10 works
- Apache-level replay of 1,400 real crawler URLs reproduced a +380 MB worker step at exactly the OPDS window; identical with/without `MALLOC_ARENA_MAX=2` (allocator exonerated)
- ~2,600 hits/day to `/api/opds/all/` variants from crawlers walking `page=1,2,3…`

## The fix
QuerySet slicing → SQL `LIMIT/OFFSET`, in `api/opds.py` and the `api/opds_json.py` twin. Ordering is applied by `Facet.feed()` before this point, so pagination semantics are unchanged. Unused `islice` imports removed (management-command uses left alone — batch jobs).

## Review
Codex (2nd AI): LGTM, no blocking findings — verified next-link probe unaffected, negative-page behavior not a regression (500 before and after; clamping is a separate hardening), JSON twin correct incl. the 50/50000 branch, checked against Django 4.2 `QuerySet.__getitem__` source.

## Deploy plan
Test-first (deploy.yml to regluit-test, verify OPDS pages + worker memory), then master → production release PR, same flow as today's #1205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZoSkYdkKLH37tH4QbEmH7