### PR TITLE
Release: OPDS SQL-side paging (#1189 root-cause fix)

### DIFF
--- a/api/opds.py
+++ b/api/opds.py
@@ -1,5 +1,4 @@
 import datetime
-from itertools import islice
 import logging
 from urllib.parse import urlparse, urlunparse
 
@@ -365,7 +364,11 @@ def opds_feed_for_works(the_facet, page=None, order_by='newest'):
                               None, order_by, group=other_group.title,
                               title=facet_object.title).prettify()
 
-    works = islice(works, 10 * page, 10 * page + 10)
+    # SQL-side slice (LIMIT/OFFSET). itertools.islice looked lazy but iterating
+    # a QuerySet runs _fetch_all(): every free work in the catalog (292k+) was
+    # materialized to serve 10 — ~360 MB per request, the memory high-water
+    # behind #1078/#1189 under OPDS crawler traffic.
+    works = works[10 * page:10 * page + 10]
     if page > 0:
         yield navlink('previous', feed_path, page-1, order_by, title="Previous 10").prettify()
 

--- a/api/opds_json.py
+++ b/api/opds_json.py
@@ -1,5 +1,4 @@
 import datetime
-from itertools import islice
 import logging
 import json
 
@@ -279,7 +278,8 @@ def opds_feed_for_works(the_facet, page=None, order_by='newest'):
                 group=other_group.title, title=facet_object.title
             )
 
-    works = islice(works, books_per_page * page, books_per_page * page + books_per_page)
+    # SQL-side slice (LIMIT/OFFSET), not islice — see api/opds.py / #1189.
+    works = works[books_per_page * page:books_per_page * page + books_per_page]
     if page > 0:
         append_navlink(links, 'previous', feed_path, page-1, order_by,
                        title="Previous {}".format(books_per_page))


### PR DESCRIPTION
Release PR: promote master → production.

Contents: [#1207](https://github.com/Gluejar/regluit/pull/1207) — OPDS feeds now page in SQL (LIMIT/OFFSET) instead of materializing all 292k catalog works per request (fixes the memory high-water behind [#1189](https://github.com/Gluejar/regluit/issues/1189)/[#1078](https://github.com/Gluejar/regluit/issues/1078)).

Rehearsed on test.unglue.it: identical feed output, single-request Python peak 362 MB → 0.5 MB, permanent worker RSS +442 MB → +0.

Deploy after merge: `ansible-playbook -i hosts deploy.yml` (code-only; no pip, no migrations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZoSkYdkKLH37tH4QbEmH7