### PR TITLE
Release: crawler-trap root-cause fix (#1209) to production

### DIFF
--- a/frontend/templates/add_your_books.html
+++ b/frontend/templates/add_your_books.html
@@ -1,4 +1,5 @@
 {% load cf %}
+{% load feedback_link %}
 	<script type="text/javascript" src="/static/js/watermark_init.js"></script>
 	<script type="text/javascript" src="/static/js/watermark_change.js"></script>
 	<p id="add_your_books"><b>Claiming a work</b></p>
@@ -20,5 +21,5 @@
 	<ul class="bullets">
 	    <li>Use <a href="{% url 'new_edition' '' '' %}">this form</a> to enter the metadata.</li>
 	    <li>Your metadata should have title, authors, language, description.</li>
-	    <li>If you have a lot of books to enter, <a href="{% url 'feedback' %}?page={{request.build_absolute_uri|urlencode:""}}">contact us</a> to load ONIX or CSV files for you.</li>
+	    <li>If you have a lot of books to enter, <a href="{% feedback_url %}">contact us</a> to load ONIX or CSV files for you.</li>
 	</ul>

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 {% load sass_tags %}
+{% load feedback_link %}
 
 <html>
 <head>
@@ -39,7 +40,7 @@
 
 <body>
 <div id="feedback">
-<p><a href="{% url 'feedback' %}?page={{request.build_absolute_uri|urlencode:""}}" class="nounderline">Feedback</a></p>
+<p><a href="{% feedback_url %}" class="nounderline">Feedback</a></p>
 </div>
 
 <div id="about_expandable">
@@ -163,7 +164,7 @@
             <li><a href="{% url 'faq' %}">General FAQ</a></li>
             <li><a href="{% url 'faq_location' 'rightsholders' %}">Author/Publisher FAQ</a></li>
             <li><a href="{% url 'api_help' %}">API</a></li>
-            <li><a href="{% url 'feedback' %}?page={{request.build_absolute_uri|urlencode:""}}">Support</a>
+            <li><a href="{% feedback_url %}">Support</a>
             <li><a href="{% url 'libraries' %}">Unglue.it for Libraries</a>
         </ul>
     </div>

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -109,10 +109,10 @@
             {% else %}
                 <div class="js-topmenu">
                     <ul class="menu">
-                        <li><a class="notbutton hijax" href="{% url 'superlogin' %}?next={% if request.GET.next %}{{ request.GET.next|urlencode }}{% else %}{{ request.get_full_path|urlencode}}{% endif %}"><span>Sign In</span></a></li>
+                        <li><a class="notbutton hijax" href="{% url 'superlogin' %}?next={% auth_next %}"><span>Sign In</span></a></li>
                        {% if not suppress_search_box %}
                             {% if request.get_full_path != "/accounts/register/" %}
-                                <li  class="last"><a class="btn btn-signup" href="{% url 'registration_register' %}?next={% if request.GET.next %}{{ request.GET.next|urlencode }}{% else %}{{ request.get_full_path|urlencode}}{% endif %}">Sign Up <i class="fa fa-chevron-right"></i></a></li>
+                                <li  class="last"><a class="btn btn-signup" href="{% url 'registration_register' %}?next={% auth_next %}">Sign Up <i class="fa fa-chevron-right"></i></a></li>
                             {% endif %}
                         {% endif %}
                     </ul>

--- a/frontend/templates/download.html
+++ b/frontend/templates/download.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load feedback_link %}
 
 {% load humanize %}
 {% load sass_tags %}
@@ -392,7 +393,7 @@ $j(document).ready(function() {
         
         <br />
         <h4>Need more help?</h4>
-        <p><a href="{% url 'feedback' %}?page={{request.build_absolute_uri|urlencode:""}}">Ask us a question!</a></p>
+        <p><a href="{% feedback_url %}">Ask us a question!</a></p>
         
         <div>
             <a href="http://www.defectivebydesign.org/drm-free"><img src="/static/images/DRM-free150.png" alt="DefectiveByDesign.org" border="0" align="middle" /></a> All downloads from Unglue.it are DRM free. Hooray!

--- a/frontend/templates/faq.html
+++ b/frontend/templates/faq.html
@@ -1,4 +1,5 @@
 {% extends 'basedocumentation.html' %}
+{% load feedback_link %}
 
 {% block title %} FAQ {% endblock %}
 {% block topsection %}
@@ -12,7 +13,7 @@
 <dl>
 <dt class="background: #8dc63f; color: white; font-weight: bold;">Help! My question isn't covered in the FAQs!</dt>
 
-<dd><a href="{% url 'feedback' %}?page={{request.build_absolute_uri|urlencode:""}}">Let us know!</a>.  We want to make sure everything on the site runs as smoothly as possible.  Thanks for helping us do that.</dd>
+<dd><a href="{% feedback_url %}">Let us know!</a>.  We want to make sure everything on the site runs as smoothly as possible.  Thanks for helping us do that.</dd>
 </dl>
 {% endif %}
 {% if location == 'basics' or location == 'faq' %}
@@ -229,7 +230,7 @@ Start by visiting the <a href="{% url 'rightsholders' %}">Rights Holders Tools</
 	<ul class="bullets">
 	    <li>Use <a href="{% url 'new_edition' '' '' %}">this form</a> to enter the metadata.</li>
 	    <li>Your metadata should have title, identifiers, authors, language, description.</li>
-	    <li>If you have a lot of books to enter, <a href="{% url 'feedback' %}?page={{request.build_absolute_uri|urlencode:""}}">contact us</a> to load ONIX or CSV files for you.</li>
+	    <li>If you have a lot of books to enter, <a href="{% feedback_url %}">contact us</a> to load ONIX or CSV files for you.</li>
 	</ul>
 <br /><br />If you expect to see a "Claim" button and do not, either we do not have a RHA from you yet, or we have not yet verified and filed it.  Please contact us at <a href="mailto:rights@ebookfoundation.org">rights@ebookfoundation.org</a>.</dd>
 

--- a/frontend/templates/gift_error.html
+++ b/frontend/templates/gift_error.html
@@ -1,14 +1,15 @@
 {% extends 'registration/registration_base.html' %}
+{% load feedback_link %}
 
 {% block title %}Invalid Gift Code{% endblock %}
 {% block doccontent %}
 <div><h2>Invalid Gift Code</h2>
     <div>
     {% if gift %}
-    <p>Sorry, the gift code you tried to use for "<a href="{% url 'work' work.id %}">{{ work.title }}</a>" has already been redeemed. If you think it should still be valid, don't hesitate to <a href="{% url 'feedback' %}?page={{request.build_absolute_uri|urlencode:""}}">contact us</a>.
+    <p>Sorry, the gift code you tried to use for "<a href="{% url 'work' work.id %}">{{ work.title }}</a>" has already been redeemed. If you think it should still be valid, don't hesitate to <a href="{% feedback_url %}">contact us</a>.
     </p>
     {% else %}
-    <p>Sorry, your gift code is invalid. Perhaps there was a problem cutting and pasting the URL? If you're having trouble, don't hesitate to contact <a href="{% url 'feedback' %}?page={{request.build_absolute_uri|urlencode:""}}">contact us</a>.
+    <p>Sorry, your gift code is invalid. Perhaps there was a problem cutting and pasting the URL? If you're having trouble, don't hesitate to contact <a href="{% feedback_url %}">contact us</a>.
     </p>
     {% endif %}
     </div>

--- a/frontend/templates/gift_user_error.html
+++ b/frontend/templates/gift_user_error.html
@@ -1,4 +1,5 @@
 {% extends 'basepledge.html' %}
+{% load feedback_link %}
 
 {% load humanize %}
 
@@ -12,7 +13,7 @@
 
 	<div><h2>Wrong user for Unglue.it credit</h2>
 		<div>
-		<p>Unglue.it would like to process your Unglue.it credit, but you are currently logged in as <code>{{request.user.username}}</code>. Your Unglue.it credit for ${{ envelope.amount }}.{{ envelope.cents }} is designated for <code>{{ envelope.username }}</code>. To record your credit, you need to <a href='{% url 'logout' %}?next={{ request.get_full_path|urlencode }}'>log out</a>, and then <a href='{% url 'superlogin' %}?next={{ request.get_full_path|urlencode }}'>log in</a> as <code>{{ envelope.username }}</code>. If you have any problem, don't hesitate to <a href="{% url 'feedback' %}?page={{request.build_absolute_uri|urlencode:""}}">contact us</a>.
+		<p>Unglue.it would like to process your Unglue.it credit, but you are currently logged in as <code>{{request.user.username}}</code>. Your Unglue.it credit for ${{ envelope.amount }}.{{ envelope.cents }} is designated for <code>{{ envelope.username }}</code>. To record your credit, you need to <a href='{% url 'logout' %}?next={{ request.get_full_path|urlencode }}'>log out</a>, and then <a href='{% url 'superlogin' %}?next={{ request.get_full_path|urlencode }}'>log in</a> as <code>{{ envelope.username }}</code>. If you have any problem, don't hesitate to <a href="{% feedback_url %}">contact us</a>.
         </p>
         </div>
 	</div>

--- a/frontend/templates/gift_welcome.html
+++ b/frontend/templates/gift_welcome.html
@@ -1,4 +1,5 @@
 {% extends 'registration/registration_base.html' %}
+{% load feedback_link %}
 
 
 {% block title %}Welcome to Unglue.It{% endblock %}
@@ -29,7 +30,7 @@
 {% endif %}
 <br />
 <div class="welcomealternatives">
-Or you can <a href="{% url 'edit_user' %}">change your username</a> &#151; <a href="{% url 'free' %}">browse free books</a>   &#151; <a href="{% url 'feedback' %}?page={{request.build_absolute_uri|urlencode:""}}">send us feedback</a> &#151; <a href="{% url 'notification_notice_settings' %}">manage your contact preferences</a>
+Or you can <a href="{% url 'edit_user' %}">change your username</a> &#151; <a href="{% url 'free' %}">browse free books</a>   &#151; <a href="{% feedback_url %}">send us feedback</a> &#151; <a href="{% url 'notification_notice_settings' %}">manage your contact preferences</a>
 </div>
 {% endblock %}
 

--- a/frontend/templates/manage_campaign.html
+++ b/frontend/templates/manage_campaign.html
@@ -1,4 +1,5 @@
 {% extends 'basedocumentation.html' %}
+{% load feedback_link %}
 
 {% load humanize %}
 {% load sass_tags %}
@@ -97,7 +98,7 @@ Please fix the following before launching your campaign:
             </div>
         {% elif campaign.type == 1 %}
             <div class="pledged-group">
-            If you believe your campaign meets <a href="{% url 'faq_sublocation' 'rightsholders' 'campaigns' %}#donation_support">the criteria for charitable donation support</a>, use <a href="{% url 'feedback' %}?page={{request.build_absolute_uri|urlencode:""}}">the feedback form</a> to request a review by Free Ebook Foundation staff.
+            If you believe your campaign meets <a href="{% url 'faq_sublocation' 'rightsholders' 'campaigns' %}#donation_support">the criteria for charitable donation support</a>, use <a href="{% feedback_url %}">the feedback form</a> to request a review by Free Ebook Foundation staff.
             </div>
         {% endif %}
     </div>
@@ -474,7 +475,7 @@ Please fix the following before launching your campaign:
             <li>Have you <a href="{% url 'work_preview' campaign.work_id %}">previewed your campaign</a>? Does it look how you want it to?</li>
         </ul>
         
-        <p>If it doesn't look exactly the way you like, or you're having any trouble with your description, we're happy to help; please <a href="{% url 'feedback' %}?page={{request.build_absolute_uri|urlencode:""}}">contact us</a>.</p>
+        <p>If it doesn't look exactly the way you like, or you're having any trouble with your description, we're happy to help; please <a href="{% feedback_url %}">contact us</a>.</p>
     
         <p>If you're happy with your campaign, here's your moment of truth!</p>
     

--- a/frontend/templates/pledge_card_error.html
+++ b/frontend/templates/pledge_card_error.html
@@ -1,4 +1,5 @@
 {% extends 'basepledge.html' %}
+{% load feedback_link %}
 
 {% load humanize %}
 
@@ -14,7 +15,7 @@
 		<div>
 		<p>Unglue.it would like to accept your credit card, but we encountered a problem: <b>{{transaction.error}}</b> {% if request.user.account_set %}Please <a href="{% url 'manage_account' %}">Update your credit card</a>,
 		{% else %}Please <a href="{{ request.get_full_path }}">try again</a>,{% endif %}
-		 or  <a href="{% url 'feedback' %}?page={{request.build_absolute_uri|urlencode:""}}">contact us</a>.
+		 or  <a href="{% feedback_url %}">contact us</a>.
         </p>
         </div>
 	</div>

--- a/frontend/templates/pledge_user_error.html
+++ b/frontend/templates/pledge_user_error.html
@@ -1,4 +1,5 @@
 {% extends 'basepledge.html' %}
+{% load feedback_link %}
 
 {% load humanize %}
 
@@ -12,7 +13,7 @@
 
 	<div><h2>Error: Wrong user for a {{ action }} transaction</h2>
 		<div>
-		<p>Unglue.it would like to process your {{ action }}, but you are currently logged in as <code>{{request.user.username}}</code>.  To complete your {{ action }}, you need to <a href='{% url 'logout' %}?next={{ request.get_full_path|urlencode }}'>log out</a>, and then <a href='{% url 'superlogin' %}?next={{ request.get_full_path|urlencode }}'>log in</a> as <code>{{ transaction.user.username }}</code>. If you have any problem, don't hesitate to <a href="{% url 'feedback' %}?page={{request.build_absolute_uri|urlencode:""}}">contact us</a>.
+		<p>Unglue.it would like to process your {{ action }}, but you are currently logged in as <code>{{request.user.username}}</code>.  To complete your {{ action }}, you need to <a href='{% url 'logout' %}?next={{ request.get_full_path|urlencode }}'>log out</a>, and then <a href='{% url 'superlogin' %}?next={{ request.get_full_path|urlencode }}'>log in</a> as <code>{{ transaction.user.username }}</code>. If you have any problem, don't hesitate to <a href="{% feedback_url %}">contact us</a>.
         </p>
         </div>
 	</div>

--- a/frontend/templates/rh_tools.html
+++ b/frontend/templates/rh_tools.html
@@ -1,4 +1,5 @@
 {% extends 'basedocumentation.html' %}
+{% load feedback_link %}
 
 {% block title %} for Rightsholders {% endblock %}
 {% block extra_extra_head %}
@@ -40,5 +41,5 @@ Any questions not covered here?  Please email us at <a href="mailto:rights@ebook
 {% endif %}
 {% block toolcontent %}{% endblock %}
 <h2>More Questions</h2>
-<p> Check the FAQ to the left, or <a href="{% url 'feedback' %}?page={{request.build_absolute_uri|urlencode:""}}">send us feedback.</a>
+<p> Check the FAQ to the left, or <a href="{% feedback_url %}">send us feedback.</a>
 {% endblock %}

--- a/frontend/templates/supporter.html
+++ b/frontend/templates/supporter.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load feedback_link %}
 
 {% load el_pagination_tags %}
 {% load sass_tags %}
@@ -269,7 +270,7 @@ function highlightTarget(targetdiv) {
                                 </div>
                             </div>
 
-                            <br /><br /><hr />We'd also love to hear your <a href="{% url 'feedback' %}?page={{request.build_absolute_uri|urlencode:""}}">feedback</a>.
+                            <br /><br /><hr />We'd also love to hear your <a href="{% feedback_url %}">feedback</a>.
                         </div>
                         {% else %}
                         <div class="empty-wishlist">

--- a/frontend/templatetags/feedback_link.py
+++ b/frontend/templatetags/feedback_link.py
@@ -10,12 +10,17 @@ one before (%2F -> %252F -> %25252F). Crawler fleets walked that space at tens
 of thousands of requests per hour on 2026-07-10 and saturated the web workers
 (see INCIDENT_2026-07-10_crawler_trap_flood.md).
 
-The guard alone terminates the recursive chain: a feedback URL can only be
-embedded into a ?page= parameter by a page that is not the feedback page, so
-nesting can never exceed one level. On all other pages the recorded URL is
-passed through exactly as the browser requested it -- including any page=
-query parameter, which is legitimate pagination state there (e.g.
-/search/?q=...&page=2).
+Two tags cooperate to make the URL space finite:
+
+- feedback_url: drops ?page= on the feedback page itself.
+- auth_next: the Sign In / Sign Up links in base.html embed the current URL
+  as ?next=. On the feedback page that would re-grow the chain sideways
+  (feedback -> superlogin?next=<feedback url> -> feedback?page=<superlogin
+  url> -> ...), so there auth_next uses the bare request.path instead of the
+  full path. Everywhere else both tags pass the browser's URL through exactly
+  -- including any page= query parameter, which is legitimate pagination
+  state (e.g. /search/?q=...&page=2). With both rules, alternating
+  feedback/login crawls reach a fixed point instead of growing.
 """
 from urllib.parse import quote
 
@@ -39,3 +44,22 @@ def feedback_url(context):
     if request is None or _on_feedback_page(request):
         return feedback
     return '%s?page=%s' % (feedback, quote(request.build_absolute_uri(), safe=''))
+
+
+@register.simple_tag(takes_context=True)
+def auth_next(context):
+    """Urlencoded value for the ?next= parameter on Sign In / Sign Up links.
+
+    Reuses an incoming ?next= verbatim (stable propagation on login and
+    registration pages); on the feedback page uses the bare path so the
+    feedback/login link chain cannot grow; otherwise the full current path.
+    """
+    request = context.get('request')
+    if request is None:
+        return ''
+    incoming = request.GET.get('next')
+    if incoming:
+        return quote(incoming, safe='')
+    if _on_feedback_page(request):
+        return quote(request.path, safe='')
+    return quote(request.get_full_path(), safe='')

--- a/frontend/templatetags/feedback_link.py
+++ b/frontend/templatetags/feedback_link.py
@@ -10,10 +10,14 @@ one before (%2F -> %252F -> %25252F). Crawler fleets walked that space at tens
 of thousands of requests per hour on 2026-07-10 and saturated the web workers
 (see INCIDENT_2026-07-10_crawler_trap_flood.md).
 
-Any existing page= parameter is also stripped from the recorded URL, so other
-query strings can't reintroduce a level of nesting.
+The guard alone terminates the recursive chain: a feedback URL can only be
+embedded into a ?page= parameter by a page that is not the feedback page, so
+nesting can never exceed one level. On all other pages the recorded URL is
+passed through exactly as the browser requested it -- including any page=
+query parameter, which is legitimate pagination state there (e.g.
+/search/?q=...&page=2).
 """
-from urllib.parse import parse_qsl, quote, urlencode, urlsplit, urlunsplit
+from urllib.parse import quote
 
 from django import template
 from django.urls import reverse
@@ -28,17 +32,10 @@ def _on_feedback_page(request):
     return request.path == reverse('feedback')
 
 
-def _strip_page_param(url):
-    parts = urlsplit(url)
-    query = [(k, v) for k, v in parse_qsl(parts.query, keep_blank_values=True) if k != 'page']
-    return urlunsplit(parts._replace(query=urlencode(query)))
-
-
 @register.simple_tag(takes_context=True)
 def feedback_url(context):
     feedback = reverse('feedback')
     request = context.get('request')
     if request is None or _on_feedback_page(request):
         return feedback
-    page = _strip_page_param(request.build_absolute_uri())
-    return '%s?page=%s' % (feedback, quote(page, safe=''))
+    return '%s?page=%s' % (feedback, quote(request.build_absolute_uri(), safe=''))

--- a/frontend/templatetags/feedback_link.py
+++ b/frontend/templatetags/feedback_link.py
@@ -1,0 +1,44 @@
+"""
+Emit the site-wide "feedback" link, with a self-reference guard.
+
+On every page except /feedback/ itself the link carries a ?page=<current-url>
+parameter so the feedback form can record where the user came from. On the
+feedback page we deliberately drop that parameter: a feedback link that points
+back to the feedback page (with the feedback page's own URL encoded into it)
+creates an infinite, self-referencing URL space -- each level re-encodes the
+one before (%2F -> %252F -> %25252F). Crawler fleets walked that space at tens
+of thousands of requests per hour on 2026-07-10 and saturated the web workers
+(see INCIDENT_2026-07-10_crawler_trap_flood.md).
+
+Any existing page= parameter is also stripped from the recorded URL, so other
+query strings can't reintroduce a level of nesting.
+"""
+from urllib.parse import parse_qsl, quote, urlencode, urlsplit, urlunsplit
+
+from django import template
+from django.urls import reverse
+
+register = template.Library()
+
+
+def _on_feedback_page(request):
+    match = getattr(request, 'resolver_match', None)
+    if match is not None and match.url_name == 'feedback':
+        return True
+    return request.path == reverse('feedback')
+
+
+def _strip_page_param(url):
+    parts = urlsplit(url)
+    query = [(k, v) for k, v in parse_qsl(parts.query, keep_blank_values=True) if k != 'page']
+    return urlunsplit(parts._replace(query=urlencode(query)))
+
+
+@register.simple_tag(takes_context=True)
+def feedback_url(context):
+    feedback = reverse('feedback')
+    request = context.get('request')
+    if request is None or _on_feedback_page(request):
+        return feedback
+    page = _strip_page_param(request.build_absolute_uri())
+    return '%s?page=%s' % (feedback, quote(page, safe=''))

--- a/frontend/tests.py
+++ b/frontend/tests.py
@@ -220,3 +220,23 @@ class GoogleBooksTest(TestCase):
         work_url = r['location']
         self.assertTrue(re.match(r'.*/work/\d+/$', work_url))
 
+class FeedbackSelfLinkTests(TestCase):
+    """Regression: the feedback page must not link back to itself with a
+    ?page=<current-url> parameter. That self-reference (emitted by the base
+    template's footer/nav on every page, including /feedback/ itself) created
+    an infinite, self-encoding URL space that crawler fleets walked at tens of
+    thousands of requests per hour on 2026-07-10, saturating the web workers.
+    See INCIDENT_2026-07-10_crawler_trap_flood.md."""
+
+    def test_feedback_page_has_no_self_referencing_link(self):
+        r = Client().get("/feedback/")
+        self.assertEqual(r.status_code, 200)
+        self.assertNotIn("/feedback/?page=", str(r.content, 'utf-8'))
+
+    def test_other_pages_still_carry_page_param(self):
+        # The footer feedback link on non-feedback pages must keep the ?page=
+        # parameter so the form can record where the user came from.
+        r = Client().get("/privacy/")
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("/feedback/?page=", str(r.content, 'utf-8'))
+

--- a/frontend/tests.py
+++ b/frontend/tests.py
@@ -233,10 +233,40 @@ class FeedbackSelfLinkTests(TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertNotIn("/feedback/?page=", str(r.content, 'utf-8'))
 
-    def test_other_pages_still_carry_page_param(self):
-        # The footer feedback link on non-feedback pages must keep the ?page=
-        # parameter so the form can record where the user came from.
+    def test_feedback_page_with_page_param_has_no_self_referencing_link(self):
+        # Even a crawler-style request that already carries an encoded
+        # feedback URL must not be handed a deeper level of nesting.
+        r = Client().get("/feedback/", {"page": "https://testserver/feedback/?page=x"})
+        self.assertEqual(r.status_code, 200)
+        self.assertNotIn("/feedback/?page=", str(r.content, 'utf-8'))
+
+    def test_other_pages_carry_exact_current_url(self):
+        # The footer feedback link on non-feedback pages must embed the exact
+        # current URL (urlencoded) so the form records where the user came from.
+        from urllib.parse import quote
         r = Client().get("/privacy/")
         self.assertEqual(r.status_code, 200)
-        self.assertIn("/feedback/?page=", str(r.content, 'utf-8'))
+        content = str(r.content, 'utf-8')
+        self.assertIn("/feedback/?page=", content)
+        self.assertIn(quote("http://testserver/privacy/", safe=''), content)
+
+    def test_pagination_state_is_preserved_in_recorded_url(self):
+        # A page= query parameter on a non-feedback page is legitimate
+        # pagination state and must survive into the recorded URL
+        # (regression guard: an earlier draft of this fix stripped it).
+        from urllib.parse import quote
+        r = Client().get("/privacy/", {"q": "sverige", "page": "2"})
+        self.assertEqual(r.status_code, 200)
+        content = str(r.content, 'utf-8')
+        self.assertIn(quote("page=2", safe=''), content)
+        self.assertIn(quote("q=sverige", safe=''), content)
+
+    def test_feedback_url_tag_without_request_in_context(self):
+        # Rendering outside a request cycle (e.g. error pages, emails) must
+        # degrade to the bare feedback URL, not raise.
+        from django.template import Context, Template
+        rendered = Template(
+            "{% load feedback_link %}{% feedback_url %}"
+        ).render(Context({}))
+        self.assertEqual(rendered, "/feedback/")
 

--- a/frontend/tests.py
+++ b/frontend/tests.py
@@ -238,7 +238,10 @@ class FeedbackSelfLinkTests(TestCase):
         # feedback URL must not be handed a deeper level of nesting.
         r = Client().get("/feedback/", {"page": "https://testserver/feedback/?page=x"})
         self.assertEqual(r.status_code, 200)
-        self.assertNotIn("/feedback/?page=", str(r.content, 'utf-8'))
+        # Assert on hrefs specifically: the form legitimately echoes the
+        # incoming page value in a hidden field / subject line, but no LINK
+        # (the crawlable surface) may carry a parameterized feedback URL.
+        self.assertNotIn('href="/feedback/?page=', str(r.content, 'utf-8'))
 
     def test_other_pages_carry_exact_current_url(self):
         # The footer feedback link on non-feedback pages must embed the exact

--- a/frontend/tests.py
+++ b/frontend/tests.py
@@ -261,6 +261,44 @@ class FeedbackSelfLinkTests(TestCase):
         self.assertIn(quote("page=2", safe=''), content)
         self.assertIn(quote("q=sverige", safe=''), content)
 
+    def test_feedback_login_chain_reaches_fixed_point(self):
+        # Codex round-2 finding: on /feedback/ the Sign In link's ?next=
+        # embedded the full feedback URL, so a crawler alternating
+        # feedback -> superlogin -> feedback -> superlogin got ever-growing
+        # URLs. With auth_next using the bare path on the feedback route,
+        # the chain must reach a fixed point instead.
+        import re
+        c = Client()
+
+        def signin_href(html):
+            m = re.search(r'href="(/accounts/superlogin/\?next=[^"]*)"', html)
+            self.assertIsNotNone(m, "no sign-in link found")
+            return m.group(1)
+
+        def feedback_href(html):
+            m = re.search(r'href="(/feedback/[^"]*)"', html)
+            self.assertIsNotNone(m, "no feedback link found")
+            return m.group(1)
+
+        url = "/feedback/?page=https%3A%2F%2Ftestserver%2Fwork%2F1%2F"
+        seen = set()
+        for _ in range(4):
+            r = c.get(url)
+            self.assertEqual(r.status_code, 200)
+            html = str(r.content, 'utf-8')
+            login = signin_href(html)
+            # next must be the bare feedback path, never a growing URL
+            self.assertEqual(login, "/accounts/superlogin/?next=%2Ffeedback%2F")
+            r2 = c.get(login)
+            self.assertEqual(r2.status_code, 200)
+            url = feedback_href(str(r2.content, 'utf-8'))
+            self.assertLess(len(url), 300, "chain URL should not grow")
+            if url in seen:
+                break
+            seen.add(url)
+        else:
+            self.fail("feedback/login chain did not reach a fixed point in 4 rounds")
+
     def test_feedback_url_tag_without_request_in_context(self):
         # Rendering outside a request cycle (e.g. error pages, emails) must
         # degrade to the bare feedback URL, not raise.


### PR DESCRIPTION
Releases [#1209](https://github.com/Gluejar/regluit/pull/1209) — the 2026-07-10 crawler-trap root cause (feedback self-link + auth `?next=` growth chain). Only change in this release (`production...master` delta = #1209 alone, verified).

**Why now**: three Apache guard layers are holding prod, but this removes the trap itself — see the [BLUF writeup](https://github.com/Gluejar/regluit/pull/1209#issuecomment-4984215223) (log-evidence based, Codex fact-checked).

**Verification**: `CC+Codex+LGTM` (3 review rounds) · 6/6 new tests green on test.unglue.it · smoke gate green on test @ `35a6c093` 2026-07-15 ~12:00 PT (feedback page emits bounded links; normal pages unchanged; search/work/download/login all green; celery active).

**Deploy**: ansible `deploy.yml` → regluit-prod (no new deps; `run_pip` not needed). Rollback point: `c99e1993`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZoSkYdkKLH37tH4QbEmH7