### PR TITLE
fix: remove crawlable keyword facets

### DIFF
--- a/api/opds.py
+++ b/api/opds.py
@@ -173,12 +173,6 @@ def work_node(work, facet=None):
             try:
                 category_node["term"] = subject.name
                 node.append(category_node)
-                try:
-                    subject.works.filter(is_free=True)[1]
-                    # Subject categories remain metadata, but are no longer
-                    # advertised as crawlable browse facets.
-                except:
-                    pass
             except ValueError:
                 # caused by control chars in subject.name
                 logger.warning('Deleting subject: %s' % subject.name)

--- a/api/opds.py
+++ b/api/opds.py
@@ -37,8 +37,6 @@ def feeds():
         yield globals()[facet]
     for facet_path in facets.get_all_facets('Format'):
         yield get_facet_facet(facet_path)
-    for facet_path in facets.get_all_facets('Keyword'):
-        yield get_facet_facet(facet_path)
 
 def get_facet_class(name):
     if name in old_facets:
@@ -177,9 +175,8 @@ def work_node(work, facet=None):
                 node.append(category_node)
                 try:
                     subject.works.filter(is_free=True)[1]
-                    # only show feed if there's another work in it
-                    node.append(navlink('related', 'kw.' + subject.name, 0,
-                                        'popular', title=subject.name))
+                    # Subject categories remain metadata, but are no longer
+                    # advertised as crawlable browse facets.
                 except:
                     pass
             except ValueError:

--- a/api/opds_json.py
+++ b/api/opds_json.py
@@ -32,8 +32,6 @@ JSONCONTEXT = "http://opds-spec.org/opds.jsonld"
 def feeds():
     for facet_path in facets.get_all_facets('Format'):
         yield get_facet_facet(facet_path)
-    for facet_path in facets.get_all_facets('Keyword'):
-        yield get_facet_facet(facet_path)
 
 def get_facet_class(name):
     return get_facet_facet(name)

--- a/api/templates/api_help.html
+++ b/api/templates/api_help.html
@@ -40,8 +40,6 @@
     <dd><code><a href="{% url 'opds_acqusition' 'by-sa' %}?page=1">{{base_url}}{% url 'opds_acqusition' 'by-sa' %}</a></code></dd>
     <dt>filtered by title search</dt>
     <dd><code><a href="{% url 'opds_acqusition' 's.open' %}?page=1">{{base_url}}{% url 'opds_acqusition' 's.open' %}</a></code></dd>
-    <dt>filtered by keyword</dt>
-    <dd><code><a href="{% url 'opds_acqusition' 'epub' %}?page=1">{{base_url}}{% url 'opds_acqusition' 'epub' %}</a></code></dd>
     <dt>filtered by ungluer</dt>
     <dd><code><a href="{% url 'opds_acqusition' '@eric' %}?page=1">{{base_url}}{% url 'opds_acqusition' '@eric' %}</a></code></dd>
     <dt>filtered by having a Project Gutenberg or DOAB identifier (doab, gtbg)</dt>

--- a/api/templates/api_help.html
+++ b/api/templates/api_help.html
@@ -41,7 +41,7 @@
     <dt>filtered by title search</dt>
     <dd><code><a href="{% url 'opds_acqusition' 's.open' %}?page=1">{{base_url}}{% url 'opds_acqusition' 's.open' %}</a></code></dd>
     <dt>filtered by keyword</dt>
-    <dd><code><a href="{% url 'opds_acqusition' 'kw.fiction' %}?page=1">{{base_url}}{% url 'opds_acqusition' 'kw.fiction' %}</a></code></dd>
+    <dd><code><a href="{% url 'opds_acqusition' 'epub' %}?page=1">{{base_url}}{% url 'opds_acqusition' 'epub' %}</a></code></dd>
     <dt>filtered by ungluer</dt>
     <dd><code><a href="{% url 'opds_acqusition' '@eric' %}?page=1">{{base_url}}{% url 'opds_acqusition' '@eric' %}</a></code></dd>
     <dt>filtered by having a Project Gutenberg or DOAB identifier (doab, gtbg)</dt>

--- a/api/tests.py
+++ b/api/tests.py
@@ -82,23 +82,17 @@ class FeedTests(TestCase):
         r = self.client.get('/api/opds/?work=%s' % self.test_work_id)
         self.assertEqual(r.status_code, 200)
 
-    def test_opds_all_keyword_alias_works(self):
+    def test_opds_removed_keyword_paths_return_404(self):
         r = self.client.get('/api/opds/all/kw.Fiction/')
-        self.assertEqual(r.status_code, 200)
-
-    def test_opds_keyword_compound_returns_404(self):
-        r = self.client.get('/api/opds/kw.Fiction/epub/')
+        self.assertEqual(r.status_code, 404)
+        r = self.client.get('/api/opds/kw.Fiction/')
         self.assertEqual(r.status_code, 404)
 
-    def test_opds_single_keyword_works(self):
-        r = self.client.get('/api/opds/kw.Fiction/')
-        self.assertEqual(r.status_code, 200)
-
-    def test_opdsjson_keyword_compound_returns_404(self):
+    def test_opdsjson_removed_keyword_returns_404(self):
         r = self.client.get('/api/opdsjson/kw.Fiction/epub/')
         self.assertEqual(r.status_code, 404)
 
-    def test_onix_keyword_compound_returns_404(self):
+    def test_onix_removed_keyword_returns_404(self):
         r = self.client.get('/api/onix/kw.Fiction/epub/')
         self.assertEqual(r.status_code, 404)
 
@@ -113,9 +107,9 @@ class FeedTests(TestCase):
         r = self.client.get('/api/onix/?work=%s' % self.test_work_id)
         self.assertEqual(r.status_code, 200)
 
-    def test_onix_all_keyword_alias_works(self):
+    def test_onix_all_removed_keyword_returns_404(self):
         r = self.client.get('/api/onix/all/kw.Fiction/')
-        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.status_code, 404)
 
 class AllowedRepoTests(TestCase):
     def setUp(self):

--- a/api/tests.py
+++ b/api/tests.py
@@ -87,13 +87,19 @@ class FeedTests(TestCase):
         self.assertEqual(r.status_code, 404)
         r = self.client.get('/api/opds/kw.Fiction/')
         self.assertEqual(r.status_code, 404)
+        r = self.client.get('/api/opds/kw.Fiction/?work=%s' % self.test_work_id)
+        self.assertEqual(r.status_code, 404)
 
     def test_opdsjson_removed_keyword_returns_404(self):
         r = self.client.get('/api/opdsjson/kw.Fiction/epub/')
         self.assertEqual(r.status_code, 404)
+        r = self.client.get('/api/opdsjson/kw.Fiction/epub/?work=%s' % self.test_work_id)
+        self.assertEqual(r.status_code, 404)
 
     def test_onix_removed_keyword_returns_404(self):
         r = self.client.get('/api/onix/kw.Fiction/epub/')
+        self.assertEqual(r.status_code, 404)
+        r = self.client.get('/api/onix/kw.Fiction/epub/?work=%s' % self.test_work_id)
         self.assertEqual(r.status_code, 404)
 
 

--- a/api/views.py
+++ b/api/views.py
@@ -196,6 +196,15 @@ class OPDSNavigationView(TemplateView):
 class OPDSAcquisitionView(View):
     json = False
     def get(self, request, *args, **kwargs):
+        facet = kwargs.get('facet')
+        if facet:
+            try:
+                if self.json:
+                    opds_json.get_facet_class(facet)()
+                else:
+                    opds.get_facet_class(facet)()
+            except InvalidFacetCombination:
+                raise Http404("Keyword facet URLs are not supported.")
         work = request.GET.get('work', None)
         if work:
             if self.json:
@@ -204,7 +213,6 @@ class OPDSAcquisitionView(View):
             else:
                 return StreamingHttpResponse(opds.opds_feed_for_work(work),
                         content_type=opds.ACQUISITION)
-        facet = kwargs.get('facet')
         page = request.GET.get('page', None)
         order_by =  request.GET.get('order_by', 'newest')
         
@@ -229,6 +237,12 @@ class OPDSAcquisitionView(View):
 
 class OnixView(View):
     def get(self, request, *args, **kwargs):
+        facet = kwargs.get('facet', 'all')
+        if facet:
+            try:
+                opds.get_facet_class(facet)()
+            except InvalidFacetCombination:
+                raise Http404("Keyword facet URLs are not supported.")
         work = request.GET.get('work', None)
 
         if work:
@@ -237,8 +251,6 @@ class OnixView(View):
             except models.Work.DoesNotExist:
                 raise Http404
             return HttpResponse(onix.onix_feed_for_work(work), content_type="text/xml")
-
-        facet = kwargs.get('facet', 'all')
 
         if not facet:
             return HttpResponseBadRequest(content='No facet provided')

--- a/core/facets.py
+++ b/core/facets.py
@@ -72,16 +72,6 @@ class BaseFacet(object):
             # don't show more facets
             return []
 
-        # Subjects (457K values) × other facets = hundreds of millions of
-        # crawlable URLs that bots exploit. See #1110.
-        # Rule: keyword facets cannot combine with any other facet type.
-        has_keyword = any(f.facet_name.startswith('kw.') for f in used)
-        if has_keyword:
-            # keyword active → no further facets allowed
-            return []
-
-        has_non_base_facet = any(f.facet_name != 'all' for f in used)
-
         if self._stash_others != None:
             return self._stash_others
 
@@ -93,9 +83,6 @@ class BaseFacet(object):
                     in_use = True
                     break
             if not in_use:
-                # If a non-keyword facet is already active, exclude keywords
-                if has_non_base_facet and isinstance(group, KeywordFacetGroup):
-                    continue
                 others.append(group)
         self._stash_others = others
         return others
@@ -226,51 +213,11 @@ class LicenseFacetGroup(FacetGroup):
                 return  "These eBooks are available under the %s license." % self.facet_name
         return LicenseFacet
 
-TOPKW = ["Fiction", "Nonfiction", "Literature",  "History", "Classic Literature", 
-    "Children's literature, English", "History and criticism", "Science", "Juvenile fiction", 
-    "Sociology", "Software", "Science Fiction"]
-
-class KeywordFacetGroup(FacetGroup):
-    
-    def __init__(self):
-        super(FacetGroup,self).__init__()
-        self.title = 'Keyword'
-        # make facets in TOPKW available for display
-        self.facets = [('kw.%s' % kw) for kw in TOPKW]
-        self.label = '{} is ...'.format(self.title)
-        
-    def has_facet(self, facet_name):
-    
-        # recognize any facet_name that starts with "kw." as a valid facet name
-        return facet_name.startswith('kw.')
-
-    def get_facet_class(self, facet_name):
-        class KeywordFacet(NamedFacet):
-            def set_name(self):
-                self.facet_name=facet_name
-                # facet_names of the form 'kw.SUBJECT' and SUBJECT is therefore the 4th character on
-                self.keyword=self.facet_name[3:].replace(';', '/')
-            def get_query_set(self):
-                return self._get_query_set().filter(subjects__name=self.keyword)
-            def template(self):
-                return 'facets/keyword.html'
-            @property    
-            def title(self):
-                return self.keyword
-            @property    
-            def label(self):
-                return self.keyword
-            @property
-            def description(self):
-                return  "%s eBooks" % self.keyword
-        return KeywordFacet    
-
 class SearchFacetGroup(FacetGroup):
     
     def __init__(self):
         super(FacetGroup,self).__init__()
         self.title = 'Search Term'
-        # make facets in TOPKW available for display
         self.facets = []
         self.label = '{} is ...'.format(self.title)
         
@@ -280,7 +227,7 @@ class SearchFacetGroup(FacetGroup):
         return facet_name.startswith('s.')
 
     def get_facet_class(self, facet_name):
-        class KeywordFacet(NamedFacet):
+        class SearchFacet(NamedFacet):
             def set_name(self):
                 self.facet_name=facet_name
                 # facet_names of the form 's.SUBJECT' and SUBJECT is therefore the 3rd character on
@@ -303,14 +250,13 @@ class SearchFacetGroup(FacetGroup):
             @property
             def description(self):
                 return  "eBooks for {}".format(self.term)
-        return KeywordFacet    
+        return SearchFacet
 
 class SupporterFacetGroup(FacetGroup):
     
     def __init__(self):
         super(FacetGroup,self).__init__()
         self.title = 'Supporter Faves'
-        # make facets in TOPKW available for display
         self.facets = []
         self.label = '{} are ...'.format(self.title)
         
@@ -389,7 +335,7 @@ class PublisherFacetGroup(FacetGroup):
         return PublisherFacet    
 
 # order of groups in facet_groups determines order of display on /free/    
-facet_groups = [KeywordFacetGroup(), FormatFacetGroup(),  LicenseFacetGroup(), PublisherFacetGroup(), IdFacetGroup(), SearchFacetGroup(), SupporterFacetGroup()]
+facet_groups = [FormatFacetGroup(),  LicenseFacetGroup(), PublisherFacetGroup(), IdFacetGroup(), SearchFacetGroup(), SupporterFacetGroup()]
 
 def get_facet(facet_name):
     for facet_group in facet_groups:
@@ -405,7 +351,7 @@ def get_all_facets(group='all'):
     return facets
 
 class InvalidFacetCombination(Exception):
-    """Raised when a keyword facet is combined with other facets (#1110)."""
+    """Raised when a removed or unsupported facet path is requested."""
     pass
 
 def get_facet_object(facet_path):
@@ -413,13 +359,11 @@ def get_facet_object(facet_path):
     if len(facets) > 1:
         # `all` is a compatibility alias for the base facet, not a real facet.
         facets = [facet for facet in facets if facet and facet != 'all']
-    # Block keyword + other facet compounds (#1110)
-    # 457K subjects × other facets = hundreds of millions of bot-crawlable URLs
+    # Subject facets were removed because their unbounded URL space attracted
+    # bot crawls. Return 404 for old links instead of serving the catalog.
     real_facets = [f for f in facets if f]
-    if len(real_facets) > 1:
-        has_keyword = any(f.startswith('kw.') for f in real_facets)
-        if has_keyword:
-            raise InvalidFacetCombination(facet_path)
+    if any(f.startswith('kw.') for f in real_facets):
+        raise InvalidFacetCombination(facet_path)
     facet_object = None
     for facet in facets[:MAX_FACETS]:
         facet_object = get_facet(facet)(facet_object)

--- a/frontend/templates/facets/keyword.html
+++ b/frontend/templates/facets/keyword.html
@@ -1,5 +1,0 @@
-<div>
-        <p style="font-size:bigger">
-        keyword: <i>{{facet.keyword}}</i> – {{ work_list.count }} free books. 
-        </p>
-</div>

--- a/frontend/templates/robots.txt
+++ b/frontend/templates/robots.txt
@@ -6,6 +6,7 @@ Disallow: /feedback/
 Disallow: /socialauth/
 Disallow: /search/
 Disallow: /googlebooks/
+Disallow: /free/kw.
 {% else %}
 User-agent: *
 Disallow: /

--- a/frontend/templates/subjectbox.html
+++ b/frontend/templates/subjectbox.html
@@ -1,5 +1,5 @@
 <div class="workbox">
-    <a href="{% url 'free' %}kw.{{ subject.name }}/">{{ subject.name }}</a> <br />
+    {{ subject.name }} <br />
     Works with this keyword: {{ subject.works.all.count }}<br />
     Free Works with this keyword:     {{ subject.free_works.count }} <br />
     <a href="{% url 'free' %}?setkw={{ subject.name }}">Set</a> keywords. <br />

--- a/frontend/templates/subjects.html
+++ b/frontend/templates/subjects.html
@@ -26,7 +26,7 @@
         <ul>
         {% for subject in subjects %}
         
-            <li><a href="{% url 'free' %}kw.{{ subject.name }}/">{{ subject.name }}</a> 
+            <li>{{ subject.name }}
             ({% if subject.works__is_free__count %}{{ subject.works__is_free__count }} free out of {{ subject.works.all.count }}{% else %}{{ subject.works__count }}{% endif %} total works). 
             {% if request.user.is_staff %} <a href="{% url 'free' %}?setkw={{ subject.name }}">set</a> keywords. 
              <a href="{% url 'admin:core_subject_change' subject.id %}">edit</a>{% endif %} keyword.

--- a/frontend/tests.py
+++ b/frontend/tests.py
@@ -155,11 +155,11 @@ class PageTests(TestCase):
 class AllFacetAliasTests(TestCase):
     fixtures = ['initial_data.json', 'neuromancer.json']
 
-    def test_all_keyword_alias_matches_keyword_path(self):
+    def test_removed_keyword_paths_return_404(self):
         plain = self.client.get("/free/kw.Fiction/?order_by=newest")
         alias = self.client.get("/free/all/kw.Fiction/?order_by=newest")
-        self.assertEqual(plain.status_code, 200)
-        self.assertEqual(alias.status_code, 200)
+        self.assertEqual(plain.status_code, 404)
+        self.assertEqual(alias.status_code, 404)
 
     def test_all_non_keyword_alias_matches_compound_path(self):
         plain = self.client.get("/free/epub/doab/?order_by=newest")
@@ -171,17 +171,11 @@ class FacetIsolationTests(TestCase):
     """Tests for #1110: keyword/subject facets cannot combine with other facets."""
     fixtures = ['initial_data.json', 'neuromancer.json']
 
-    def test_base_free_page_offers_keywords(self):
-        """The base /free/ page should offer keyword facets in the sidebar."""
+    def test_base_free_page_omits_keywords(self):
+        """The base /free/ page should not advertise keyword facets."""
         r = self.client.get("/free/")
         self.assertEqual(r.status_code, 200)
-        self.assertContains(r, "Keyword")
-
-    def test_keyword_page_no_refine_sidebar(self):
-        """A keyword facet page should NOT offer further facet refinement."""
-        r = self.client.get("/free/kw.Fiction/")
-        self.assertEqual(r.status_code, 200)
-        self.assertNotContains(r, "Show me only")
+        self.assertNotContains(r, "Keyword")
 
     def test_non_keyword_page_excludes_keywords(self):
         """A non-keyword facet page should offer refinement but NOT keywords."""
@@ -190,9 +184,9 @@ class FacetIsolationTests(TestCase):
         self.assertContains(r, "Show me only")
         self.assertNotContains(r, "Keyword")
 
-    def test_single_keyword_still_works(self):
+    def test_removed_keyword_path_returns_404(self):
         r = self.client.get("/free/kw.Fiction/")
-        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.status_code, 404)
 
     def test_keyword_compound_returns_404(self):
         r = self.client.get("/free/kw.Fiction/epub/")
@@ -202,9 +196,9 @@ class FacetIsolationTests(TestCase):
         r = self.client.get("/free/epub/kw.Fiction/")
         self.assertEqual(r.status_code, 404)
 
-    def test_keyword_with_all_prefix_still_works(self):
+    def test_removed_keyword_with_all_prefix_returns_404(self):
         r = self.client.get("/free/all/kw.Fiction/")
-        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.status_code, 404)
 
     def test_non_keyword_compound_still_works(self):
         r = self.client.get("/free/epub/doab/")

--- a/tests/bdd/features/opds_feeds.feature
+++ b/tests/bdd/features/opds_feeds.feature
@@ -10,12 +10,11 @@ Feature: OPDS feeds
     And the page contains "<feed"
     And the page contains "<entry"
 
-  Scenario: OPDS single keyword feed works
+  Scenario: OPDS keyword feed is removed
     Given I visit "/api/opds/kw.Fiction/"
-    Then the response status is 200
-    And the content type contains "xml"
+    Then the response status is 404
 
-  Scenario: OPDS compound keyword returns 404
+  Scenario: OPDS compound keyword remains unavailable
     Given I visit "/api/opds/kw.Fiction/kw.Science/"
     Then the response status is 404
 
@@ -30,6 +29,6 @@ Feature: OPDS feeds
     Then the response status is 200
     And the content type contains "xml"
 
-  Scenario: ONIX compound keyword returns 404
+  Scenario: ONIX keyword feed remains unavailable
     Given I visit "/api/onix/kw.Fiction/kw.Science/"
     Then the response status is 404


### PR DESCRIPTION
## Summary

- remove the keyword facet group and its template so `/free/kw.*` is no longer a browse surface
- keep subject metadata and the `/subjects/` page, but remove dead facet links
- stop advertising keyword feeds in OPDS and add a defensive robots rule
- update HTML, API, and BDD coverage for the removed paths

This is the focused cleanup requested in #1095. The remaining format, license, publisher, collection, search, and supporter facets are unchanged.

## Validation

- `python -m compileall -q core api frontend`
- `git diff --check`
- Django tests are blocked in this Windows checkout because the repository dependencies are not installed (`celery` is missing).

Fixes #1095