### PR TITLE
Release: fail-safe courtesy email in Stripe webhook (#1226 / #1216)

### DIFF
--- a/payment/stripelib.py
+++ b/payment/stripelib.py
@@ -913,20 +913,31 @@ class Processor(baseprocessor.Processor):
                         pass
                 elif resource == 'customer':
                     if action == 'created':
-                        # test application: email support
-                        # do we have a flag to indicate production vs non-production?
-                        #  -- or does it matter?
-                        # email support whenever a new Customer created
-                        # -- we probably want to replace this with some other
-                        # more useful long tem action.
-                        send_mail(
-                            "Stripe Customer (id {0};  description: {1}) created".format(
-                                ev_object.get("id"),
-                                ev_object.get("description")),
-                            "Stripe Customer email: {0}".format(ev_object.get("email")),
-                            "notices@gluejar.com",
-                            ["unglueit@ebookfoundation.org"])
-                        logger.info("email sent for customer.created for %s", ev_object.get("id"))
+                        # Courtesy FYI to support whenever a new Customer is created.
+                        # MUST be fail-safe (#1216): this runs synchronously inside
+                        # the webhook request, and an unhandled mail exception turns
+                        # into a 500, which makes Stripe re-deliver the event on
+                        # backoff for days — each retry re-attempting the same send
+                        # and (before this guard) emailing ADMINS a traceback every
+                        # time. The email is informational; the webhook's job is
+                        # recording the event, and that must succeed regardless.
+                        # (Observed live 2026-08-23: a transient SES failure turned
+                        # one $5 donation into three webhook 500s.)
+                        try:
+                            send_mail(
+                                "Stripe Customer (id {0};  description: {1}) created".format(
+                                    ev_object.get("id"),
+                                    ev_object.get("description")),
+                                "Stripe Customer email: {0}".format(ev_object.get("email")),
+                                "notices@gluejar.com",
+                                ["unglueit@ebookfoundation.org"])
+                            logger.info("email sent for customer.created for %s", ev_object.get("id"))
+                        except Exception:
+                            # keep the traceback in the log; do NOT re-raise
+                            logger.exception(
+                                "courtesy email failed for customer.created %s "
+                                "(webhook still returns 200; see #1216)",
+                                ev_object.get("id"))
                     # handle updated, deleted
                     else:
                         pass

--- a/payment/tests.py
+++ b/payment/tests.py
@@ -6,6 +6,7 @@ import os
 import time
 import traceback
 import unittest
+from unittest import mock
 
 from datetime import timedelta
 from decimal import Decimal as D
@@ -425,3 +426,54 @@ def suite():
     return suites    
         
        
+
+
+class StripeWebhookCourtesyEmailTest(TestCase):
+    """#1216: a failing courtesy email must not 500 the Stripe webhook.
+
+    The customer.created handler sends an FYI email to support synchronously.
+    Before the guard, any transient mail failure (observed live 2026-08-23: an
+    intermittent SES auth error) escaped ProcessIPN, the webhook returned 500,
+    and Stripe re-delivered the event on backoff for days — re-attempting the
+    same send and emailing ADMINS a traceback on every retry.
+    """
+
+    def _post_event(self):
+        from django.test import RequestFactory
+        return RequestFactory().post(
+            "/handleipn/stripelib",
+            data='{"id": "evt_test_1216"}',
+            content_type="application/json",
+        )
+
+    def _fake_event(self):
+        class _Obj(dict):
+            pass
+        event = mock.MagicMock()
+        event.get = {"type": "customer.created"}.get
+        data = mock.MagicMock()
+        data.object = _Obj(
+            {"id": "cus_test", "description": "test", "email": "t@example.org"})
+        event.data = data
+        return event
+
+    def test_mail_failure_does_not_500_the_webhook(self):
+        from regluit.payment import stripelib
+
+        with mock.patch.object(stripelib, "StripeClient") as sc:
+            sc.return_value.event.retrieve.return_value = self._fake_event()
+            with mock.patch.object(
+                    stripelib, "send_mail",
+                    side_effect=Exception("SES transient auth failure")):
+                response = stripelib.Processor().ProcessIPN(self._post_event())
+        self.assertEqual(response.status_code, 200)
+
+    def test_mail_success_still_sends(self):
+        from regluit.payment import stripelib
+
+        with mock.patch.object(stripelib, "StripeClient") as sc:
+            sc.return_value.event.retrieve.return_value = self._fake_event()
+            with mock.patch.object(stripelib, "send_mail") as sent:
+                response = stripelib.Processor().ProcessIPN(self._post_event())
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(sent.call_count, 1)


### PR DESCRIPTION
Release: **[#1226](https://github.com/Gluejar/regluit/pull/1226)** — fixes [#1216](https://github.com/Gluejar/regluit/issues/1216). Sole content of this release.

**Why now:** the unguarded courtesy email is producing one webhook 500 per day on prod right now (Stripe retrying the 2026-08-23 gate-donation's `customer.created` event — latest retry 03:29 UTC today). Each retry also risks an ADMINS traceback email.

**Contents:** one `try/except` + `logger.exception` around the only unguarded `send_mail` in `stripelib`, plus 2 regression tests (failure case verified to ERROR against unguarded code). No migration, no dependency change, no static change → plain `deploy.yml` restart, no flags.

**Rollback:** redeploy `ecfb6262` (current `production` tip).

**Live verification:** the stuck Stripe event retries ~daily; the next retry returning **200** (instead of 500) is the natural end-to-end proof, expected within ~24h of deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGNAvPnAPCuS2vFAg6AiBB