### PR TITLE
Release: Django 4.2 → 5.2 LTS (#1203 / #1081)

### DIFF
--- a/booxtream/tests.py
+++ b/booxtream/tests.py
@@ -61,7 +61,7 @@ class TestBooXtream(unittest.TestCase):
             }
         params['referenceid'] = 'order' + str(time.time())
         boox = inst.platform(epubfile=self.epub2file, **params)
-        self.assertRegexpMatches(boox.download_link_epub, 'download.booxtream.com/')
+        self.assertRegex(boox.download_link_epub, 'download.booxtream.com/')
         self.assertFalse(boox.expired)
         self.assertEqual(boox.downloads_remaining, 3)
 
@@ -71,4 +71,4 @@ class TestBooXtream(unittest.TestCase):
         in_mem_epub.write(self.epub2file.read())
         in_mem_epub.seek(0)
         boox2 = inst.platform(epubfile=in_mem_epub, **params)
-        self.assertRegexpMatches(boox2.download_link_epub, 'download.booxtream.com/')
+        self.assertRegex(boox2.download_link_epub, 'download.booxtream.com/')

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -422,8 +422,12 @@ class Campaign(models.Model):
             self.created = None
             self.name = 'copy of %s' % self.name
             self.activated = None
-            self.update_left()
+            # save() BEFORE update_left(): update_left() -> current_total filters
+            # Transactions on this instance, and Django 5.x raises ValueError for
+            # unsaved instances in related filters (4.2 silently matched nothing).
+            # A fresh clone has no transactions, so the computed totals are identical.
             self.save()
+            self.update_left()
             self.managers.set(old_managers)
 
             # clone associated premiums

--- a/core/tests.py
+++ b/core/tests.py
@@ -1099,8 +1099,8 @@ class EbookFileTests(TestCase):
         self.assertIsNot(acq.nonce, None)
 
         url = acq.get_watermarked().download_link_epub
-        self.assertRegexpMatches(url, 'github.com/eshellman/42_ebook/blob/master/download/42')
-        #self.assertRegexpMatches(url, 'booxtream.com/')
+        self.assertRegex(url, 'github.com/eshellman/42_ebook/blob/master/download/42')
+        #self.assertRegex(url, 'booxtream.com/')
 
         with self.assertRaises(UnglueitError) as cm:
             c.activate()

--- a/libraryauth/tests.py
+++ b/libraryauth/tests.py
@@ -88,7 +88,9 @@ class TestAppConfigSignalsWired(TestCase):
         # ready() must have imported signals.py and connected the dedup receiver.
         from django_registration.signals import user_activated
         names = []
-        for _key, ref in user_activated.receivers:
+        for entry in user_activated.receivers:
+            # Django <5.0: (lookup_key, receiver); Django >=5.0: (lookup_key, receiver, is_async)
+            ref = entry[1]
             fn = ref if getattr(ref, '__name__', None) else (ref() if callable(ref) else None)
             names.append(getattr(fn, '__name__', None))
         self.assertIn('handle_same_email_account', names)

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ cryptography==41.0.7; python_version >= '3.7'
 cssselect2==0.7.0; python_version >= '3.7'
 defusedxml==0.8.0rc2; python_version >= '3.6'
 distlib==0.3.8
-django==4.2.21
+django==5.2.15
 django-ckeditor==6.7.3
 nh3==0.3.6  # server-side HTML sanitization of CKEditor rich text (security-private#26)
 django-el-pagination==4.1.2
@@ -29,10 +29,10 @@ django-el-pagination==4.1.2
 django-extensions==3.1.1; python_version >= '3.6'
 django-js-asset==2.2.0
 # django-jsonfield removed — using Django 3.2+ native models.JSONField
-django-mptt==0.14.0
+django-mptt==0.18.0
 -e git+https://github.com/Gluejar/django-notification.git@2a7c138#egg=django-notification
 django-registration==3.4
-django-sass-processor==0.8.2
+django-sass-processor==1.4.2
 django-selectable==1.5.0
 django-storages==1.14.6
 docopt==0.6.2

--- a/settings/common.py
+++ b/settings/common.py
@@ -44,6 +44,13 @@ USE_I18N = True
 # USE_L10N was removed in Django 5.0 (localized formatting is always on), so it
 # is intentionally not set here.
 
+# Django 5.0 flipped the USE_TZ default from False to True. This codebase (and
+# the production database contents) use naive local datetimes throughout, so we
+# pin the pre-5.0 behavior. Migrating to timezone-aware datetimes is a separate
+# project (data migration + audit of every datetime comparison), not part of the
+# 4.2 -> 5.2 upgrade.
+USE_TZ = False
+
 # Absolute filesystem path to the directory that will hold user-uploaded files.
 # Example: "/home/media/media.lawrence.com/media/"
 MEDIA_ROOT = ''


### PR DESCRIPTION
Release: **[#1203](https://github.com/Gluejar/regluit/pull/1203) — Django 4.2.21 → 5.2.15 LTS** (supported to April 2028). Sole content of this release.

## Rollback point

**`70ec22ee`** — current `production` tip. **This release has no migration and no pending schema change** (`migrate --plan`: empty), so rollback is a plain redeploy of that SHA at any time. Snapshot `prod-pre-django52-20260826` taken anyway as belt.

## Evidence

- **Staging soak**: test.unglue.it has served **~300k requests on this exact tree** (5.2 + #1226, `05f4692b`) since Sunday evening — zero application errors, three clean nightly-cron cycles. (Only blips: a vuln-scanner probe pattern that produces identical transient 5xx on production's 4.2 — framework-independent.)
- **Logged-in flows verified Monday**: campaign management incl. legacy-B2U fail-closed launch gate, THANKS-only creation form (+ hand-crafted POST rejection), notification history/settings, registration POST, sass CSS.
- **Local suites**: failure sets identical between 4.2 and 5.2 on the same tree; 16 scrub tests + 2 webhook tests green under both.
- **Codex reviews**: original spike LGTM; rebased diff re-reviewed 2026-08-23 (range-diff verified, LGTM).
- **Eric**: informed 8/24 with deploy intent, replied same day, no objection (per the note's stated silence-consent protocol). Post-deploy review on the 11:15 call today.

## Deploy sequence

1. Snapshot complete (gate)
2. `deploy.yml` with `run_pip=true run_collectstatic=true` (framework + sass-processor bumps)
3. Verify: Django **5.2.15** from `/opt/regluit/venv`, services active, pages 200
4. `pip uninstall django-contrib-comments` (inert leftover; proven absent on staging)
5. End-to-end gate: live $5 donation through the new framework
6. Watch window; overnight monitors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGNAvPnAPCuS2vFAg6AiBB