### PR TITLE
Consolidate donation funds: General Fund only (#1230)

### DIFF
--- a/frontend/forms/__init__.py
+++ b/frontend/forms/__init__.py
@@ -45,7 +45,6 @@ from regluit.core.parameters import (
     REWARDS,
     BUY2UNGLUE,
     THANKS,
-    DONATION_CHOICES,
 )
 from regluit.core.lookups import (
     OwnerLookup,
@@ -339,18 +338,11 @@ class DonationForm(forms.Form):
         decimal_places=2,
         label="Donation Amount",
     )
-    # Donations only support the General Fund now (#1230). Historical
+    # No `reason`/fund field (#1230): donations only support the General
+    # Fund now, hardcoded in NewDonationView.form_valid rather than read
+    # from POST data, so there's no field here to omit or spoof. Historical
     # transactions with reason="monographs" are unaffected -- FUNDS and
-    # Transaction.reason are untouched -- but new donations can no longer
-    # choose it, on this form or via a crafted POST. Kept as a hidden
-    # field (rather than dropped) so NewDonationView.form_valid's
-    # form.cleaned_data.get("reason", "") keeps working unchanged.
-    reason = forms.ChoiceField(
-        choices=(("general", "The FEF General Fund"),),
-        initial="general",
-        required=False,
-        widget=forms.HiddenInput(),
-    )
+    # Transaction.reason are untouched.
 
 
 class CampaignPledgeForm(forms.Form):

--- a/frontend/forms/__init__.py
+++ b/frontend/forms/__init__.py
@@ -332,7 +332,6 @@ class CampaignThanksForm(forms.Form):
         pe = PledgeExtra( anonymous=self.cleaned_data['anonymous'] )
 
 class DonationForm(forms.Form):
-    # used only for validation; not currently used for display
     amount = forms.DecimalField(
         required = True,
         min_value=D('5.00'),
@@ -340,7 +339,18 @@ class DonationForm(forms.Form):
         decimal_places=2,
         label="Donation Amount",
     )
-    reason = forms.ChoiceField(choices=DONATION_CHOICES, required=False)
+    # Donations only support the General Fund now (#1230). Historical
+    # transactions with reason="monographs" are unaffected -- FUNDS and
+    # Transaction.reason are untouched -- but new donations can no longer
+    # choose it, on this form or via a crafted POST. Kept as a hidden
+    # field (rather than dropped) so NewDonationView.form_valid's
+    # form.cleaned_data.get("reason", "") keeps working unchanged.
+    reason = forms.ChoiceField(
+        choices=(("general", "The FEF General Fund"),),
+        initial="general",
+        required=False,
+        widget=forms.HiddenInput(),
+    )
 
 
 class CampaignPledgeForm(forms.Form):

--- a/frontend/templates/about_funds.html
+++ b/frontend/templates/about_funds.html
@@ -27,7 +27,6 @@ If you want to support a specific ungluing campaign, donate to that campaign dir
 <h2 id="donationform">Donate Now!</h2>
                     <div id="authorize" class="jsmod-content" >
             <form class="askform" method="POST" action="{% url 'newdonation' %}">
-                <input type="hidden" name="reason" value="general">
                     <div class="donate_amount clearfix">
                     <label>Amount ($): </label><input id="amount" max="20000.00" min="5.00" name="amount" step="0.01" type="number" value="10.00" class="donate"></div>
                     <div class="button">

--- a/frontend/templates/about_funds.html
+++ b/frontend/templates/about_funds.html
@@ -13,45 +13,16 @@
 <h2> Donating to Unglue.it </h2>
 <p>
 Unglue.it is a program of the <a href="https://ebookfoundation.org">Free Ebook Foundation</a> (FEF), which is a charitable, not-for-profit corporation. 
-Donations to the Free Ebook Foundation are tax-deductible in the United States.
+Donations to the Free Ebook Foundation are tax-deductible in the United States, and support the operation and maintenance of the Foundation's programs, including Unglue.it, Free-Programming-Books, and our work supporting Project Gutenberg.
 </p>
 <p>
-When you donate to the Free Ebook Foundation, you can specify how you would like your donation to be used. There are currently two options:
-</p>
-<ul class="bullets">
-<li> <a href="#monographs">The FEF Open Access Monographs Fund</a>: to support the Ungluing of peer-reviewed monographs that advance scholarship, science and learning </li>
-<li> <a href="#general">The FEF General Fund</a>: to support the operation and maintenance of the Foundation's programs, including Unglue.it.
-</ul>
-<h3 id="monographs">The FEF Open Access Monograph Fund</h3>
-<p>
-Scholars write books to spread their ideas, so it makes sense to make them free and available. 
-We refer to these books as "monographs" because they usually embody the scholarship of a single author.
-Already, over 30,000 of these books are available to download from the Unglue.it database.
-Sadly, many more books are locked up behind paywalls - not because their authors want to make money, but because the publishers of these books need to recoup the cost of editorial work and design.
-Many new books will remain unpublished because publishers committed to Open Access have insufficient resources to publish all the books deserving of wider audiences.
-</p>
-<p>
-As a small step towards addressing these needs, we're offering donors a chance to help us unglue more of these monographs by donating to a special fund.
-The fund will be used to match contributions to qualified ungluing campaigns on Unglue.it. 
-To participate, authors should first work with a publisher to establish a campaign target, and then create an ungluing campaign. 
-To get started, follow the steps at our <a href="{% url 'rightsholders' %}">right holder tools page</a>.
-Our staff will verify that the book has been or will be peer-reviewed and advances scholarship, science and learning. 
-Resources from the fund will be allocated to maximize the success of the eligible campaigns.
-If you want to donate to a specific campaign, just donate to the campaign directly. 
-</p>
-<h3 id="general">The FEF General Fund</h3>
-<p>
-If you prefer to support all the work of the Free Ebook Foundation, including Unglue.it, Free-Programming-Books, and our work supporting Project Gutenberg, just use the General Fund.
+If you want to support a specific ungluing campaign, donate to that campaign directly.
 </p>
 
 <h2 id="donationform">Donate Now!</h2>
                     <div id="authorize" class="jsmod-content" >
-            <form class="askform" method="POST" action="{% url 'newdonation' %}">  
-                <p class=" form-row clearfix">
-                    <input id="id_reason_monographs" checked type="radio" value="monographs" name="reason"><label for="id_reason_monographs">FEF Open Access Monographs Fund</label>              
-                </p> <p class=" form-row clearfix">
-                    <input id="id_reason_general" type="radio" value="general" name="reason"><label for="id_reason_general">FEF General Fund</label>
-                </p> 
+            <form class="askform" method="POST" action="{% url 'newdonation' %}">
+                <input type="hidden" name="reason" value="general">
                     <div class="donate_amount clearfix">
                     <label>Amount ($): </label><input id="amount" max="20000.00" min="5.00" name="amount" step="0.01" type="number" value="10.00" class="donate"></div>
                     <div class="button">

--- a/frontend/templates/about_funds.html
+++ b/frontend/templates/about_funds.html
@@ -10,6 +10,11 @@
 
 {% block doccontent %}
 
+<!-- Named anchors kept for old donation-confirmation links (pledge_complete.html
+     links to about_funds#{{ transaction.reason }}) now that there's only one
+     fund: both #general (new donations) and #monographs (historical donations)
+     land here at the top of the page. -->
+<a id="general"></a><a id="monographs"></a>
 <h2> Donating to Unglue.it </h2>
 <p>
 Unglue.it is a program of the <a href="https://ebookfoundation.org">Free Ebook Foundation</a> (FEF), which is a charitable, not-for-profit corporation. 

--- a/frontend/templates/home.html
+++ b/frontend/templates/home.html
@@ -172,8 +172,7 @@ function put_un_in_cookie2(){
                 	<h3 class="module-title">Donate!</h3>
                     <div class="jsmod-content">
                                  <div>Please help support Unglue.it by making a tax-deductible donation to the Free Ebook Foundation.</div>
-            <form class="askform" method="POST" action="{% url 'newdonation' %}">  
-                    <input type="hidden" value="general" name="reason">              
+            <form class="askform" method="POST" action="{% url 'newdonation' %}">
                     <div class="donate_amount">
                     <label>Amount ($): </label><input id="amount" max="20000.00" min="5.00" name="amount" step="0.01" type="number" value="10.00" class="donate"></div>
                     <div class="button">

--- a/frontend/views/__init__.py
+++ b/frontend/views/__init__.py
@@ -883,9 +883,12 @@ class NewDonationView(FormView):
     form_class = DonationForm
     def form_valid(self, form):
         p = PaymentManager()
+        # Donations only support the General Fund now (#1230) -- hardcoded
+        # rather than read from POST data, so there's no field to omit or
+        # spoof. Historical "monographs"-reason transactions are unaffected.
         t, url = p.process_transaction('USD',  form.cleaned_data["amount"],
                                        user=self.request.user,
-                                       paymentReason=form.cleaned_data.get("reason", ""),
+                                       paymentReason="general",
                                       )
         if url:
             return HttpResponseRedirect(url)


### PR DESCRIPTION
Closes #1230. Eric answered the open accounting question via Slack 8/27: past Monographs-fund donations are **not** restricted funds in FEF's accounting → per the issue's own framing this is the "quick win" path, no reporting-surface changes needed.

**Change**: `about_funds.html` drops the Monographs-fund choice and copy. Donors see one General Fund pitch. `DonationForm` no longer has a `reason` field at all — `NewDonationView.form_valid` hardcodes `paymentReason="general"` directly, so there's no POST field to omit, blank, or spoof.

**3 rounds of Codex review, `CC+Codex+LGTM`** (each round caught something real):
- R1: `DonationForm` still exposed the full two-choice field via `{{ form.as_p }}` on GET/invalid-POST (`fund_the_pledge.html` → `cardform.html`), and a crafted `reason=monographs` POST still validated. A stale code comment ("not currently used for display") is what led me to miss this the first time.
- R1: donation-confirmation pages link to `about_funds.html#{{ transaction.reason }}` — restored `#general`/`#monographs` as no-op anchors so old links still land on the page.
- R2: my first fix (`required=False` hidden `ChoiceField`) still let an omitted/blank `reason` through as `""` (empty fund name, dead `#` link) — `initial=` only fills unbound forms, not missing POST data. Fixed by removing the field entirely and hardcoding `general` in the view.
- R3 (LGTM with nits): verified no path can produce `reason != "general"` for new donations. Cleaned up the homepage's own donate form, which had the same now-inert hidden field.

**Kept unchanged (deliberately, per issue scope)**:
- `payment/parameters.py` `FUNDS` mapping and `payment/models.py` `Transaction.reason` — historical `reason="monographs"` transactions keep rendering with their original label.
- No migration.

Searched all templates/`.py` for other "monograph" references — only bibliographic/BISAC hits unrelated to the fund; nothing else to update.

**Not fixed here** (Codex's other nit, deliberately out of scope): a regression test for the donation-reason paths — tracked under #1215 (existing payment-path test-coverage issue), not added here to keep this PR minimal.

Not touched here (separate issues): donation-form UX modernization (#1142), donate-flow discoverability (#1229).

🤖 Generated with [Claude Code](https://claude.com/claude-code)