### PR TITLE
Add opt-in email allowlist/redirect backend for non-prod (backstop for #1238)

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -569,13 +569,25 @@ DOWNLOAD_LOGS_MAX = 499
 # (password resets, gift notices, campaign emails, ...) would deliver to
 # those real people. Off by default (empty string) so production, and any
 # environment that hasn't explicitly opted in, are unaffected.
+#
+# IMPORTANT if you're touching settings after this point: this must be the
+# LAST thing in the settings chain to set EMAIL_BACKEND. Any settings module
+# that does `from .common import *` and then re-sets EMAIL_BACKEND itself
+# (settings/spike.py already does exactly this, for an unrelated reason)
+# silently defeats this safety net. Verified 2026-08-31 that the actual
+# deploy template (regluit-provisioning/roles/regluit_prod/templates/
+# prod.py.j2, which is what test.unglue.it/unglue.it actually run as
+# regluit.settings.prod) does NOT re-set EMAIL_BACKEND after `from .common
+# import *` -- but that's an external file this repo doesn't control, so it
+# stays a live risk for any future change there. (CC review, 2026-08-31.)
+from regluit.utils.safe_email_backend import resolve_email_backend  # noqa: E402
+
 EMAIL_SAFE_MODE = os.environ.get('EMAIL_SAFE_MODE', '').strip().lower() in ('1', 'true', 'yes')
+SAFE_EMAIL_REAL_BACKEND, EMAIL_BACKEND = resolve_email_backend(
+    EMAIL_SAFE_MODE,
+    globals().get('EMAIL_BACKEND', 'django.core.mail.backends.smtp.EmailBackend'),
+)
 if EMAIL_SAFE_MODE:
-    SAFE_EMAIL_REAL_BACKEND = os.environ.get(
-        'SAFE_EMAIL_REAL_BACKEND',
-        globals().get('EMAIL_BACKEND', 'django.core.mail.backends.smtp.EmailBackend'),
-    )
-    EMAIL_BACKEND = 'regluit.utils.safe_email_backend.AllowlistEmailBackend'
     EMAIL_SAFE_MODE_ALLOWED_DOMAINS = os.environ.get('EMAIL_SAFE_MODE_ALLOWED_DOMAINS', '')
     EMAIL_SAFE_MODE_ALLOWED_ADDRESSES = os.environ.get('EMAIL_SAFE_MODE_ALLOWED_ADDRESSES', '')
     EMAIL_SAFE_MODE_REDIRECT_TO = os.environ.get('EMAIL_SAFE_MODE_REDIRECT_TO', '')

--- a/settings/common.py
+++ b/settings/common.py
@@ -562,3 +562,20 @@ STORAGES = {
 
 # we wond't record downloads for an ebook if their more than this in a month
 DOWNLOAD_LOGS_MAX = 499
+
+# Non-production email safety net (regluit#1238). A staging/test box whose
+# database has been refreshed from a copy of production holds real users'
+# real email addresses -- without this, its normal mail-sending code
+# (password resets, gift notices, campaign emails, ...) would deliver to
+# those real people. Off by default (empty string) so production, and any
+# environment that hasn't explicitly opted in, are unaffected.
+EMAIL_SAFE_MODE = os.environ.get('EMAIL_SAFE_MODE', '').strip().lower() in ('1', 'true', 'yes')
+if EMAIL_SAFE_MODE:
+    SAFE_EMAIL_REAL_BACKEND = os.environ.get(
+        'SAFE_EMAIL_REAL_BACKEND',
+        globals().get('EMAIL_BACKEND', 'django.core.mail.backends.smtp.EmailBackend'),
+    )
+    EMAIL_BACKEND = 'regluit.utils.safe_email_backend.AllowlistEmailBackend'
+    EMAIL_SAFE_MODE_ALLOWED_DOMAINS = os.environ.get('EMAIL_SAFE_MODE_ALLOWED_DOMAINS', '')
+    EMAIL_SAFE_MODE_ALLOWED_ADDRESSES = os.environ.get('EMAIL_SAFE_MODE_ALLOWED_ADDRESSES', '')
+    EMAIL_SAFE_MODE_REDIRECT_TO = os.environ.get('EMAIL_SAFE_MODE_REDIRECT_TO', '')

--- a/settings/common.py
+++ b/settings/common.py
@@ -265,6 +265,17 @@ LOGGING = {
             'handlers': ['downloads'],
             'propagate': False,
         },
+        # Without an explicit entry here, LOGGING's disable_existing_loggers
+        # (True, above) disables this logger outright the moment
+        # settings/common.py imports regluit.utils.safe_email_backend --
+        # verified live (Codex review round 2, 2026-08-31): its ERROR calls
+        # (the ones meant to make a Celery-swallowed send refusal visible;
+        # see EMAIL_SAFE_MODE below) silently did nothing without this.
+        'regluit.utils.safe_email_backend': {
+            'handlers': ['file'],
+            'level': 'ERROR',
+            'propagate': False,
+        },
         '': {
             'handlers': ['file'],
             'level': 'INFO',

--- a/utils/safe_email_backend.py
+++ b/utils/safe_email_backend.py
@@ -156,16 +156,18 @@ class AllowlistEmailBackend(BaseEmailBackend):
             # Log at ERROR (not just raise) because Celery's send_mail_task
             # swallows exceptions from backends without re-raising, which
             # would otherwise make this look like a silently dropped
-            # email. Deliberately does NOT log the actual recipient
-            # addresses -- that would recreate the exact PII-in-logs
-            # exposure the subject/body split above exists to avoid
-            # (Codex review round 2, 2026-08-31); a count is enough to
-            # know something needs fixing.
+            # email. Deliberately logs neither the actual recipient
+            # addresses nor the subject -- a first pass here logged the
+            # subject as a "safe" identifier, but a subject can itself
+            # carry PII (e.g. "Password reset for real@example.com"),
+            # recreating the exact exposure the subject/body split above
+            # exists to avoid (Codex review round 3, 2026-08-31). A bare
+            # count is enough to know something needs fixing.
             logger.error(
-                "AllowlistEmailBackend: refusing to send a message "
-                "(subject=%r) to %d recipient(s) -- not fully allowlisted "
-                "and no EMAIL_SAFE_MODE_REDIRECT_TO configured.",
-                message.subject, len(recipients),
+                "AllowlistEmailBackend: refusing to send a message to %d "
+                "recipient(s) -- not fully allowlisted and no "
+                "EMAIL_SAFE_MODE_REDIRECT_TO configured.",
+                len(recipients),
             )
             raise RuntimeError(
                 "AllowlistEmailBackend: a message to {} recipient(s) is not "

--- a/utils/safe_email_backend.py
+++ b/utils/safe_email_backend.py
@@ -15,9 +15,9 @@ message:
 - lets it through unchanged if every recipient (To/Cc/Bcc) is on the
   allowlist (``EMAIL_SAFE_MODE_ALLOWED_DOMAINS`` / ``_ADDRESSES``);
 - otherwise redirects the *whole* message to
-  ``EMAIL_SAFE_MODE_REDIRECT_TO``, with the original recipients recorded in
-  the subject and appended to the body, so a tester can still see what
-  *would* have gone out;
+  ``EMAIL_SAFE_MODE_REDIRECT_TO``, with the original recipients appended to
+  the body (subject stays generic), so a tester can still see what *would*
+  have gone out;
 - refuses to send (raises, rather than silently dropping or silently
   delivering to an unknown address) if a message needs redirecting but no
   ``EMAIL_SAFE_MODE_REDIRECT_TO`` is configured.
@@ -81,12 +81,23 @@ def _bare_address(address):
 
 
 def _is_allowed(address, allowed_domains, allowed_addresses):
-    address = _bare_address(address).strip().lower()
-    if not address:
-        return True  # nothing to protect against an empty recipient slot
-    if address in allowed_addresses:
+    raw = (address or '').strip()
+    if not raw:
+        return True  # nothing to protect against an unused recipient slot
+    parsed = _bare_address(raw).strip().lower()
+    if not parsed:
+        # Non-empty input that parseaddr couldn't extract a clean address
+        # from -- e.g. a malformed compound value like
+        # "real@example.com, ok@allowed.org" parses to ('', ''), which
+        # earlier treated the same as "nothing here" and let it through
+        # unredirected (real fail-open bypass, Codex review round 2,
+        # 2026-08-31, verified live: parseaddr() really does return that).
+        # An unparseable-but-nonempty value is suspicious, not harmless --
+        # fail closed.
+        return False
+    if parsed in allowed_addresses:
         return True
-    domain = address.rsplit('@', 1)[-1] if '@' in address else ''
+    domain = parsed.rsplit('@', 1)[-1] if '@' in parsed else ''
     return bool(domain) and domain in allowed_domains
 
 
@@ -142,21 +153,26 @@ class AllowlistEmailBackend(BaseEmailBackend):
             return message
 
         if not self.redirect_to:
+            # Log at ERROR (not just raise) because Celery's send_mail_task
+            # swallows exceptions from backends without re-raising, which
+            # would otherwise make this look like a silently dropped
+            # email. Deliberately does NOT log the actual recipient
+            # addresses -- that would recreate the exact PII-in-logs
+            # exposure the subject/body split above exists to avoid
+            # (Codex review round 2, 2026-08-31); a count is enough to
+            # know something needs fixing.
             logger.error(
-                "AllowlistEmailBackend: refusing to send a message to %r -- "
-                "not fully allowlisted and no EMAIL_SAFE_MODE_REDIRECT_TO "
-                "configured. Logged at ERROR (not just raised) because "
-                "Celery's send_mail_task swallows exceptions from backends "
-                "without re-raising, which would otherwise make this look "
-                "like a silently dropped email.",
-                recipients,
+                "AllowlistEmailBackend: refusing to send a message "
+                "(subject=%r) to %d recipient(s) -- not fully allowlisted "
+                "and no EMAIL_SAFE_MODE_REDIRECT_TO configured.",
+                message.subject, len(recipients),
             )
             raise RuntimeError(
-                "AllowlistEmailBackend: message to {!r} is not fully "
-                "allowlisted (EMAIL_SAFE_MODE_ALLOWED_DOMAINS/_ADDRESSES) "
-                "and EMAIL_SAFE_MODE_REDIRECT_TO is not set, so there's "
-                "nowhere safe to send it. Refusing to send rather than "
-                "guess.".format(recipients)
+                "AllowlistEmailBackend: a message to {} recipient(s) is not "
+                "fully allowlisted (EMAIL_SAFE_MODE_ALLOWED_DOMAINS/"
+                "_ADDRESSES) and EMAIL_SAFE_MODE_REDIRECT_TO is not set, so "
+                "there's nowhere safe to send it. Refusing to send rather "
+                "than guess.".format(len(recipients))
             )
 
         redirected = copy.copy(message)
@@ -186,7 +202,8 @@ class AllowlistEmailBackend(BaseEmailBackend):
             raise RuntimeError(
                 "AllowlistEmailBackend: rewriting recipients to the "
                 "redirect target didn't take effect (message.recipients() "
-                "still returns {!r}) -- this message type can't be safely "
-                "redirected. Refusing to send.".format(actual)
+                "still returns {} address(es), not just the redirect "
+                "target) -- this message type can't be safely redirected. "
+                "Refusing to send.".format(len(actual))
             )
         return redirected

--- a/utils/safe_email_backend.py
+++ b/utils/safe_email_backend.py
@@ -1,0 +1,111 @@
+"""Allowlist/redirect email backend for non-production environments.
+
+Any environment whose database might be (or become) a copy of production
+data holds real users' real email addresses. Without this backend, that
+environment's normal Django mail-sending code (password resets, gift
+notices, campaign emails, etc.) would deliver real email to real people --
+exactly what happened on test.unglue.it 2026-08-31 after its database was
+refreshed from a prod snapshot (see regluit#1238).
+
+Enabled by setting ``EMAIL_SAFE_MODE=true`` (see settings/common.py, which
+then points ``EMAIL_BACKEND`` at ``AllowlistEmailBackend`` below). Wraps
+whatever the real backend would otherwise have been and, for each outgoing
+message:
+
+- lets it through unchanged if every recipient (To/Cc/Bcc) is on the
+  allowlist (``EMAIL_SAFE_MODE_ALLOWED_DOMAINS`` / ``_ADDRESSES``);
+- otherwise redirects the *whole* message to
+  ``EMAIL_SAFE_MODE_REDIRECT_TO``, with the original recipients recorded in
+  the subject and appended to the body, so a tester can still see what
+  *would* have gone out;
+- refuses to send (raises, rather than silently dropping or silently
+  delivering to an unknown address) if a message needs redirecting but no
+  ``EMAIL_SAFE_MODE_REDIRECT_TO`` is configured.
+
+Silent dropping is deliberately not an option here -- it's exactly the kind
+of behavior that made two earlier staging-email incidents (regluit#1164,
+regluit-provisioning#22) more confusing to diagnose than they needed to be:
+"nothing happened" looks identical to "it's broken" and to "it's working
+correctly," and no one incident is more common than the others.
+"""
+import copy
+
+from django.conf import settings
+from django.utils.module_loading import import_string
+
+DEFAULT_REAL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+
+
+def _is_allowed(address, allowed_domains, allowed_addresses):
+    address = (address or '').strip().lower()
+    if not address:
+        return True  # nothing to protect against an empty recipient slot
+    if address in allowed_addresses:
+        return True
+    domain = address.rsplit('@', 1)[-1] if '@' in address else ''
+    return bool(domain) and domain in allowed_domains
+
+
+class AllowlistEmailBackend:
+    """Wraps another EMAIL_BACKEND, redirecting non-allowlisted mail."""
+
+    def __init__(self, fail_silently=False, **kwargs):
+        real_backend_path = getattr(
+            settings, 'SAFE_EMAIL_REAL_BACKEND', DEFAULT_REAL_BACKEND
+        )
+        real_backend_cls = import_string(real_backend_path)
+        self.real_backend = real_backend_cls(fail_silently=fail_silently, **kwargs)
+        self.fail_silently = fail_silently
+
+        self.allowed_domains = {
+            d.strip().lower()
+            for d in getattr(settings, 'EMAIL_SAFE_MODE_ALLOWED_DOMAINS', '').split(',')
+            if d.strip()
+        }
+        self.allowed_addresses = {
+            a.strip().lower()
+            for a in getattr(settings, 'EMAIL_SAFE_MODE_ALLOWED_ADDRESSES', '').split(',')
+            if a.strip()
+        }
+        self.redirect_to = getattr(settings, 'EMAIL_SAFE_MODE_REDIRECT_TO', '') or None
+
+    def open(self):
+        return self.real_backend.open()
+
+    def close(self):
+        return self.real_backend.close()
+
+    def send_messages(self, email_messages):
+        if not email_messages:
+            return 0
+        prepared = [self._redirect_if_needed(m) for m in email_messages]
+        return self.real_backend.send_messages(prepared)
+
+    def _redirect_if_needed(self, message):
+        recipients = list(message.to) + list(message.cc) + list(message.bcc)
+        if all(_is_allowed(r, self.allowed_domains, self.allowed_addresses) for r in recipients):
+            return message
+
+        if not self.redirect_to:
+            raise RuntimeError(
+                "AllowlistEmailBackend: message to {!r} is not fully "
+                "allowlisted (EMAIL_SAFE_MODE_ALLOWED_DOMAINS/_ADDRESSES) "
+                "and EMAIL_SAFE_MODE_REDIRECT_TO is not set, so there's "
+                "nowhere safe to send it. Refusing to send rather than "
+                "guess.".format(recipients)
+            )
+
+        redirected = copy.copy(message)
+        original_recipients = ', '.join(recipients) if recipients else '(no recipients)'
+        redirected.to = [self.redirect_to]
+        redirected.cc = []
+        redirected.bcc = []
+        redirected.subject = '[STAGING, would have gone to: {}] {}'.format(
+            original_recipients, message.subject
+        )
+        redirect_note = (
+            '\n\n---\n[Redirected by AllowlistEmailBackend -- this message was '
+            'addressed to: {}]\n'.format(original_recipients)
+        )
+        redirected.body = (message.body or '') + redirect_note
+        return redirected

--- a/utils/safe_email_backend.py
+++ b/utils/safe_email_backend.py
@@ -27,12 +27,22 @@ of behavior that made two earlier staging-email incidents (regluit#1164,
 regluit-provisioning#22) more confusing to diagnose than they needed to be:
 "nothing happened" looks identical to "it's broken" and to "it's working
 correctly," and no one incident is more common than the others.
+
+Deploying this to an actual box (setting EMAIL_SAFE_MODE=true + an
+allowlist/redirect address in its environment, for both the web process AND
+Celery) is a separate, provisioning-side step -- not done by this module
+existing in the codebase. See regluit#1238.
 """
 import copy
+import logging
 import os
+from email.utils import parseaddr
 
 from django.conf import settings
+from django.core.mail.backends.base import BaseEmailBackend
 from django.utils.module_loading import import_string
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_REAL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 ALLOWLIST_BACKEND_PATH = 'regluit.utils.safe_email_backend.AllowlistEmailBackend'
@@ -64,8 +74,14 @@ def resolve_email_backend(email_safe_mode, current_backend, env=None):
     return real_backend, ALLOWLIST_BACKEND_PATH
 
 
+def _bare_address(address):
+    """Extract the bare address from an optional 'Display Name <addr>' form."""
+    _, addr = parseaddr(address or '')
+    return addr
+
+
 def _is_allowed(address, allowed_domains, allowed_addresses):
-    address = (address or '').strip().lower()
+    address = _bare_address(address).strip().lower()
     if not address:
         return True  # nothing to protect against an empty recipient slot
     if address in allowed_addresses:
@@ -74,16 +90,22 @@ def _is_allowed(address, allowed_domains, allowed_addresses):
     return bool(domain) and domain in allowed_domains
 
 
-class AllowlistEmailBackend:
-    """Wraps another EMAIL_BACKEND, redirecting non-allowlisted mail."""
+class AllowlistEmailBackend(BaseEmailBackend):
+    """Wraps another EMAIL_BACKEND, redirecting non-allowlisted mail.
+
+    Subclasses Django's BaseEmailBackend (not a bare object) so it supports
+    everything the real interface promises, including use as a context
+    manager (`with get_connection() as conn: ...`) -- caught missing in CC
+    review, 2026-08-31.
+    """
 
     def __init__(self, fail_silently=False, **kwargs):
+        super().__init__(fail_silently=fail_silently, **kwargs)
         real_backend_path = getattr(
             settings, 'SAFE_EMAIL_REAL_BACKEND', DEFAULT_REAL_BACKEND
         )
         real_backend_cls = import_string(real_backend_path)
         self.real_backend = real_backend_cls(fail_silently=fail_silently, **kwargs)
-        self.fail_silently = fail_silently
 
         self.allowed_domains = {
             d.strip().lower()
@@ -110,11 +132,25 @@ class AllowlistEmailBackend:
         return self.real_backend.send_messages(prepared)
 
     def _redirect_if_needed(self, message):
-        recipients = list(message.to) + list(message.cc) + list(message.bcc)
+        # message.recipients() -- not message.to/.cc/.bcc directly -- is
+        # Django's own authoritative list of who a message actually goes
+        # to; a message subclass can override it to include recipients
+        # that never appear in .to/.cc/.bcc at all. Checking .to/.cc/.bcc
+        # would miss those (CC review, 2026-08-31).
+        recipients = list(message.recipients())
         if all(_is_allowed(r, self.allowed_domains, self.allowed_addresses) for r in recipients):
             return message
 
         if not self.redirect_to:
+            logger.error(
+                "AllowlistEmailBackend: refusing to send a message to %r -- "
+                "not fully allowlisted and no EMAIL_SAFE_MODE_REDIRECT_TO "
+                "configured. Logged at ERROR (not just raised) because "
+                "Celery's send_mail_task swallows exceptions from backends "
+                "without re-raising, which would otherwise make this look "
+                "like a silently dropped email.",
+                recipients,
+            )
             raise RuntimeError(
                 "AllowlistEmailBackend: message to {!r} is not fully "
                 "allowlisted (EMAIL_SAFE_MODE_ALLOWED_DOMAINS/_ADDRESSES) "
@@ -128,12 +164,29 @@ class AllowlistEmailBackend:
         redirected.to = [self.redirect_to]
         redirected.cc = []
         redirected.bcc = []
-        redirected.subject = '[STAGING, would have gone to: {}] {}'.format(
-            original_recipients, message.subject
+        # Deliberately generic subject -- subjects are far more likely than
+        # bodies to end up in SMTP logs, mailbox indexing, or downstream
+        # notifications, so the original recipients (real PII once a box
+        # holds a prod DB copy) go in the body only (CC review, 2026-08-31).
+        redirected.subject = '[STAGING - redirected by AllowlistEmailBackend] {}'.format(
+            message.subject
         )
         redirect_note = (
             '\n\n---\n[Redirected by AllowlistEmailBackend -- this message was '
             'addressed to: {}]\n'.format(original_recipients)
         )
         redirected.body = (message.body or '') + redirect_note
+
+        # Belt-and-suspenders: if message.recipients() is overridden in a
+        # way that setting .to/.cc/.bcc doesn't actually change, refuse to
+        # send rather than assume the rewrite worked (CC review,
+        # 2026-08-31).
+        actual = list(redirected.recipients())
+        if actual != [self.redirect_to]:
+            raise RuntimeError(
+                "AllowlistEmailBackend: rewriting recipients to the "
+                "redirect target didn't take effect (message.recipients() "
+                "still returns {!r}) -- this message type can't be safely "
+                "redirected. Refusing to send.".format(actual)
+            )
         return redirected

--- a/utils/safe_email_backend.py
+++ b/utils/safe_email_backend.py
@@ -29,11 +29,39 @@ regluit-provisioning#22) more confusing to diagnose than they needed to be:
 correctly," and no one incident is more common than the others.
 """
 import copy
+import os
 
 from django.conf import settings
 from django.utils.module_loading import import_string
 
 DEFAULT_REAL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+ALLOWLIST_BACKEND_PATH = 'regluit.utils.safe_email_backend.AllowlistEmailBackend'
+
+
+def resolve_email_backend(email_safe_mode, current_backend, env=None):
+    """Decide what EMAIL_BACKEND (and, when active, what real backend to
+    wrap) a settings module should use, given whether EMAIL_SAFE_MODE is on.
+
+    Pulled out as a plain function -- not inlined in settings/common.py --
+    specifically so it's directly unit-testable. Django's test runner
+    (setup_test_environment) unconditionally overwrites settings.EMAIL_BACKEND
+    with the locmem backend before any TestCase body runs, which means a
+    test that imports django.conf.settings and checks EMAIL_BACKEND from
+    inside a TestCase can never actually observe what settings/common.py
+    computed -- an assertion like that would pass even if this logic were
+    broken (CC review, 2026-08-31, on the first version of this file that
+    inlined the conditional directly in common.py). Testing this function
+    directly, with no settings module or test runner involved, avoids that
+    trap entirely.
+
+    Returns (real_backend_to_wrap, effective_email_backend).
+    """
+    if env is None:
+        env = os.environ
+    if not email_safe_mode:
+        return current_backend, current_backend
+    real_backend = env.get('SAFE_EMAIL_REAL_BACKEND', current_backend)
+    return real_backend, ALLOWLIST_BACKEND_PATH
 
 
 def _is_allowed(address, allowed_domains, allowed_addresses):

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from unittest import mock
 from unittest.mock import MagicMock
@@ -11,6 +12,20 @@ from regluit.utils.safe_email_backend import (
     _is_allowed,
     resolve_email_backend,
 )
+
+
+class TestLoggerNotDisabled(TestCase):
+    def test_safe_email_backend_logger_is_not_disabled(self):
+        # settings/common.py's LOGGING sets disable_existing_loggers=True;
+        # without an explicit 'regluit.utils.safe_email_backend' entry in
+        # LOGGING['loggers'], that silently disables this module's logger
+        # the moment settings/common.py imports it -- meaning the ERROR
+        # log call in _redirect_if_needed() (the one specifically there to
+        # make a Celery-swallowed send-refusal visible) would do nothing.
+        # Verified live and fixed in settings/common.py (Codex review
+        # round 2, 2026-08-31).
+        log = logging.getLogger('regluit.utils.safe_email_backend')
+        self.assertFalse(log.disabled)
 
 
 class TestIsAllowed(TestCase):
@@ -40,6 +55,15 @@ class TestIsAllowed(TestCase):
         # just because of the display-name wrapper (CC review, 2026-08-31).
         self.assertTrue(_is_allowed(
             'Eric Hellman <eric@ebookfoundation.org>', {'ebookfoundation.org'}, set(),
+        ))
+
+    def test_malformed_compound_value_fails_closed(self):
+        # Real bypass found by Codex review round 2, 2026-08-31:
+        # parseaddr("real@example.com, ok@allowed.org") returns ('', '') --
+        # an unparseable non-empty value used to be treated the same as
+        # "no recipient here" and let through. It must fail closed instead.
+        self.assertFalse(_is_allowed(
+            'real@example.com, ok@ebookfoundation.org', {'ebookfoundation.org'}, set(),
         ))
 
 
@@ -153,9 +177,14 @@ class TestAllowlistEmailBackend(TestCase):
         # loudly so the gap gets noticed and configured, not shipped quiet.
         backend = self._backend_with_fake_real()
         msg = EmailMessage(subject='x', body='y', to=['realuser@example.com'])
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(RuntimeError) as ctx:
             backend.send_messages([msg])
         backend.real_backend.send_messages.assert_not_called()
+        # The exception text itself must not carry the real address either
+        # -- a count is enough to diagnose; whatever catches/logs this
+        # exception elsewhere shouldn't become a second PII leak (Codex
+        # review round 2, 2026-08-31).
+        self.assertNotIn('realuser@example.com', str(ctx.exception))
 
     def test_empty_message_list_is_a_noop(self):
         backend = self._backend_with_fake_real()

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -186,6 +186,26 @@ class TestAllowlistEmailBackend(TestCase):
         # review round 2, 2026-08-31).
         self.assertNotIn('realuser@example.com', str(ctx.exception))
 
+    @override_settings(EMAIL_SAFE_MODE_REDIRECT_TO='')
+    def test_refusal_log_line_carries_no_pii(self):
+        # A first-pass fix logged the subject as a "safe" stand-in for the
+        # actual recipient list -- but a subject can itself carry PII
+        # (e.g. "Password reset for real@example.com"), recreating the
+        # exposure the subject/body split exists to avoid. The log record
+        # must carry neither the recipient address nor the subject text
+        # (Codex review round 3, 2026-08-31).
+        backend = self._backend_with_fake_real()
+        msg = EmailMessage(
+            subject='Reset for realuser@example.com',
+            body='y', to=['realuser@example.com'],
+        )
+        with self.assertLogs('regluit.utils.safe_email_backend', level='ERROR') as logs:
+            with self.assertRaises(RuntimeError):
+                backend.send_messages([msg])
+        self.assertEqual(1, len(logs.output))
+        self.assertNotIn('realuser@example.com', logs.output[0])
+        self.assertNotIn('Reset for', logs.output[0])
+
     def test_empty_message_list_is_a_noop(self):
         backend = self._backend_with_fake_real()
         result = backend.send_messages([])

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -1,10 +1,16 @@
+import os
+from unittest import mock
 from unittest.mock import MagicMock
 
-from django.conf import settings
 from django.core.mail import EmailMessage
 from django.test import TestCase, override_settings
 
-from regluit.utils.safe_email_backend import AllowlistEmailBackend, _is_allowed
+from regluit.utils.safe_email_backend import (
+    ALLOWLIST_BACKEND_PATH,
+    AllowlistEmailBackend,
+    _is_allowed,
+    resolve_email_backend,
+)
 
 
 class TestIsAllowed(TestCase):
@@ -109,13 +115,43 @@ class TestAllowlistEmailBackend(TestCase):
         backend.real_backend.send_messages.assert_not_called()
 
 
-class TestEmailSafeModeSettingWiring(TestCase):
-    def test_email_safe_mode_off_by_default(self):
-        # In the test environment EMAIL_SAFE_MODE is not set, so production
-        # (and any environment that hasn't explicitly opted in) must never
-        # accidentally inherit the allowlist backend.
-        self.assertFalse(getattr(settings, 'EMAIL_SAFE_MODE', False))
-        self.assertNotEqual(
-            'regluit.utils.safe_email_backend.AllowlistEmailBackend',
-            settings.EMAIL_BACKEND,
+class TestResolveEmailBackend(TestCase):
+    """Regression guard for settings/common.py's EMAIL_SAFE_MODE wiring.
+
+    This is deliberately NOT a test that imports django.conf.settings and
+    checks EMAIL_BACKEND from inside a TestCase -- Django's test runner
+    (setup_test_environment) unconditionally overwrites
+    settings.EMAIL_BACKEND with the locmem backend before any test body
+    runs, so a check like that would pass even if settings/common.py's
+    conditional were broken (accidentally unconditional, inverted, etc.) --
+    caught in CC review, 2026-08-31. Testing resolve_email_backend()
+    directly, with no settings module involved, is what actually exercises
+    the decision logic settings/common.py delegates to.
+    """
+
+    def test_off_leaves_backend_unchanged(self):
+        real, effective = resolve_email_backend(False, 'some.RealBackend', env={})
+        self.assertEqual('some.RealBackend', real)
+        self.assertEqual('some.RealBackend', effective)
+
+    def test_on_wraps_the_current_backend_by_default(self):
+        real, effective = resolve_email_backend(True, 'some.RealBackend', env={})
+        self.assertEqual('some.RealBackend', real)
+        self.assertEqual(ALLOWLIST_BACKEND_PATH, effective)
+
+    def test_on_honors_an_explicit_real_backend_override(self):
+        real, effective = resolve_email_backend(
+            True, 'some.RealBackend',
+            env={'SAFE_EMAIL_REAL_BACKEND': 'django.core.mail.backends.console.EmailBackend'},
         )
+        self.assertEqual('django.core.mail.backends.console.EmailBackend', real)
+        self.assertEqual(ALLOWLIST_BACKEND_PATH, effective)
+
+    def test_defaults_to_os_environ_when_no_env_passed(self):
+        # settings/common.py calls this with no `env` argument in
+        # production -- confirm that path reads the real process
+        # environment rather than silently doing nothing.
+        with mock.patch.dict(os.environ, {'SAFE_EMAIL_REAL_BACKEND': 'x.RealBackend'}):
+            real, effective = resolve_email_backend(True, 'some.RealBackend')
+        self.assertEqual('x.RealBackend', real)
+        self.assertEqual(ALLOWLIST_BACKEND_PATH, effective)

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -35,6 +35,13 @@ class TestIsAllowed(TestCase):
         # 'ebookfoundation.org' via a loose substring check.
         self.assertFalse(_is_allowed('x@notebookfoundation.org', {'ebookfoundation.org'}, set()))
 
+    def test_display_name_form_is_parsed(self):
+        # "Person <addr>" must match on the bare address, not fail closed
+        # just because of the display-name wrapper (CC review, 2026-08-31).
+        self.assertTrue(_is_allowed(
+            'Eric Hellman <eric@ebookfoundation.org>', {'ebookfoundation.org'}, set(),
+        ))
+
 
 @override_settings(
     EMAIL_SAFE_MODE_ALLOWED_DOMAINS='ebookfoundation.org,gluejar.com',
@@ -71,7 +78,6 @@ class TestAllowlistEmailBackend(TestCase):
         backend.send_messages([msg])
         sent = backend.real_backend.send_messages.call_args[0][0]
         self.assertEqual(['staging-catchall@ebookfoundation.org'], sent[0].to)
-        self.assertIn('realuser@example.com', sent[0].subject)
         self.assertIn('realuser@example.com', sent[0].body)
         # The original message object passed in by calling code is never
         # mutated -- only the copy handed to the real backend is changed.
@@ -87,7 +93,7 @@ class TestAllowlistEmailBackend(TestCase):
         sent = backend.real_backend.send_messages.call_args[0][0]
         self.assertEqual(['staging-catchall@ebookfoundation.org'], sent[0].to)
 
-    def test_cc_and_bcc_are_checked_too(self):
+    def test_cc_is_checked_too(self):
         backend = self._backend_with_fake_real()
         msg = EmailMessage(
             subject='Notice', body='body', to=['someone@ebookfoundation.org'],
@@ -97,6 +103,49 @@ class TestAllowlistEmailBackend(TestCase):
         sent = backend.real_backend.send_messages.call_args[0][0]
         self.assertEqual(['staging-catchall@ebookfoundation.org'], sent[0].to)
         self.assertEqual([], sent[0].cc)
+
+    def test_bcc_is_checked_too(self):
+        backend = self._backend_with_fake_real()
+        msg = EmailMessage(
+            subject='Notice', body='body', to=['someone@ebookfoundation.org'],
+            bcc=['realuser@example.com'],
+        )
+        backend.send_messages([msg])
+        sent = backend.real_backend.send_messages.call_args[0][0]
+        self.assertEqual(['staging-catchall@ebookfoundation.org'], sent[0].to)
+        self.assertEqual([], sent[0].bcc)
+
+    def test_subject_stays_generic_pii_goes_in_body_only(self):
+        # Subjects are far more likely than bodies to end up in SMTP logs
+        # or mailbox indexing -- the real recipient must not appear there
+        # (CC review, 2026-08-31).
+        backend = self._backend_with_fake_real()
+        msg = EmailMessage(subject='Password reset', body='click here', to=['realuser@example.com'])
+        backend.send_messages([msg])
+        sent = backend.real_backend.send_messages.call_args[0][0]
+        self.assertNotIn('realuser@example.com', sent[0].subject)
+        self.assertIn('realuser@example.com', sent[0].body)
+
+    def test_overridden_recipients_that_bypass_to_cc_bcc_are_caught(self):
+        # A message subclass could override recipients() to include an
+        # address that never appears in .to/.cc/.bcc at all -- checking
+        # only .to/.cc/.bcc would let it straight through unredirected.
+        # Real bypass found by CC review, 2026-08-31; fixed by checking
+        # message.recipients() instead.
+        class SneakyMessage(EmailMessage):
+            def recipients(self):
+                return list(super().recipients()) + ['hidden-real@example.com']
+
+        backend = self._backend_with_fake_real()
+        msg = SneakyMessage(subject='Notice', body='body', to=['someone@ebookfoundation.org'])
+        # The hidden hardcoded recipient can't be cleared by setting
+        # .to/.cc/.bcc (recipients() is overridden to always add it back),
+        # so the belt-and-suspenders post-rewrite check must refuse to
+        # send it at all rather than pass it through as if it had been
+        # safely redirected.
+        with self.assertRaises(RuntimeError):
+            backend.send_messages([msg])
+        backend.real_backend.send_messages.assert_not_called()
 
     @override_settings(EMAIL_SAFE_MODE_REDIRECT_TO='')
     def test_refuses_to_send_without_a_redirect_target(self):
@@ -113,6 +162,15 @@ class TestAllowlistEmailBackend(TestCase):
         result = backend.send_messages([])
         self.assertEqual(0, result)
         backend.real_backend.send_messages.assert_not_called()
+
+    def test_usable_as_a_context_manager(self):
+        # Subclassing BaseEmailBackend (not a bare object) is what makes
+        # `with backend:` work at all -- the previous version raised
+        # TypeError here (CC review, 2026-08-31).
+        backend = self._backend_with_fake_real()
+        with backend as conn:
+            self.assertIs(backend, conn)
+        backend.real_backend.close.assert_called()
 
 
 class TestResolveEmailBackend(TestCase):

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -1,0 +1,121 @@
+from unittest.mock import MagicMock
+
+from django.conf import settings
+from django.core.mail import EmailMessage
+from django.test import TestCase, override_settings
+
+from regluit.utils.safe_email_backend import AllowlistEmailBackend, _is_allowed
+
+
+class TestIsAllowed(TestCase):
+    def test_allowed_domain(self):
+        self.assertTrue(_is_allowed('someone@ebookfoundation.org', {'ebookfoundation.org'}, set()))
+
+    def test_allowed_address(self):
+        self.assertTrue(_is_allowed('raymond.yee@gmail.com', set(), {'raymond.yee@gmail.com'}))
+
+    def test_not_allowed(self):
+        self.assertFalse(_is_allowed('realuser@example.com', {'ebookfoundation.org'}, set()))
+
+    def test_case_insensitive(self):
+        self.assertTrue(_is_allowed('Someone@EbookFoundation.ORG', {'ebookfoundation.org'}, set()))
+
+    def test_empty_address_is_harmless(self):
+        # Nothing to protect against an unused To/Cc/Bcc slot.
+        self.assertTrue(_is_allowed('', {'ebookfoundation.org'}, set()))
+
+    def test_domain_confusion_not_allowed(self):
+        # 'notebookfoundation.org' must not match an allowlisted
+        # 'ebookfoundation.org' via a loose substring check.
+        self.assertFalse(_is_allowed('x@notebookfoundation.org', {'ebookfoundation.org'}, set()))
+
+
+@override_settings(
+    EMAIL_SAFE_MODE_ALLOWED_DOMAINS='ebookfoundation.org,gluejar.com',
+    EMAIL_SAFE_MODE_ALLOWED_ADDRESSES='raymond.yee@gmail.com',
+    EMAIL_SAFE_MODE_REDIRECT_TO='staging-catchall@ebookfoundation.org',
+)
+class TestAllowlistEmailBackend(TestCase):
+    """Regression guard for regluit#1238: a staging box whose DB is a copy
+    of production must never deliver real email to real users. Constructing
+    AllowlistEmailBackend() is safe in a test even with the real SMTP
+    backend as its default wrapped class -- Django's SMTP backend doesn't
+    open a socket until send_messages()/open() is actually called, and
+    every test here swaps in a MagicMock before calling send_messages().
+    """
+
+    def _backend_with_fake_real(self):
+        backend = AllowlistEmailBackend()
+        backend.real_backend = MagicMock()
+        backend.real_backend.send_messages.return_value = 1
+        return backend
+
+    def test_fully_allowlisted_message_passes_through_unchanged(self):
+        backend = self._backend_with_fake_real()
+        msg = EmailMessage(subject='Hi', body='body', to=['someone@ebookfoundation.org'])
+        backend.send_messages([msg])
+        sent = backend.real_backend.send_messages.call_args[0][0]
+        self.assertEqual(1, len(sent))
+        self.assertIs(sent[0], msg)
+        self.assertEqual(['someone@ebookfoundation.org'], sent[0].to)
+
+    def test_non_allowlisted_message_is_redirected(self):
+        backend = self._backend_with_fake_real()
+        msg = EmailMessage(subject='Password reset', body='click here', to=['realuser@example.com'])
+        backend.send_messages([msg])
+        sent = backend.real_backend.send_messages.call_args[0][0]
+        self.assertEqual(['staging-catchall@ebookfoundation.org'], sent[0].to)
+        self.assertIn('realuser@example.com', sent[0].subject)
+        self.assertIn('realuser@example.com', sent[0].body)
+        # The original message object passed in by calling code is never
+        # mutated -- only the copy handed to the real backend is changed.
+        self.assertEqual(['realuser@example.com'], msg.to)
+
+    def test_mixed_allowlisted_and_real_recipients_still_redirects(self):
+        backend = self._backend_with_fake_real()
+        msg = EmailMessage(
+            subject='Notice', body='body',
+            to=['someone@ebookfoundation.org', 'realuser@example.com'],
+        )
+        backend.send_messages([msg])
+        sent = backend.real_backend.send_messages.call_args[0][0]
+        self.assertEqual(['staging-catchall@ebookfoundation.org'], sent[0].to)
+
+    def test_cc_and_bcc_are_checked_too(self):
+        backend = self._backend_with_fake_real()
+        msg = EmailMessage(
+            subject='Notice', body='body', to=['someone@ebookfoundation.org'],
+            cc=['realuser@example.com'],
+        )
+        backend.send_messages([msg])
+        sent = backend.real_backend.send_messages.call_args[0][0]
+        self.assertEqual(['staging-catchall@ebookfoundation.org'], sent[0].to)
+        self.assertEqual([], sent[0].cc)
+
+    @override_settings(EMAIL_SAFE_MODE_REDIRECT_TO='')
+    def test_refuses_to_send_without_a_redirect_target(self):
+        # No silent drop, no silent send to an unknown address -- fail
+        # loudly so the gap gets noticed and configured, not shipped quiet.
+        backend = self._backend_with_fake_real()
+        msg = EmailMessage(subject='x', body='y', to=['realuser@example.com'])
+        with self.assertRaises(RuntimeError):
+            backend.send_messages([msg])
+        backend.real_backend.send_messages.assert_not_called()
+
+    def test_empty_message_list_is_a_noop(self):
+        backend = self._backend_with_fake_real()
+        result = backend.send_messages([])
+        self.assertEqual(0, result)
+        backend.real_backend.send_messages.assert_not_called()
+
+
+class TestEmailSafeModeSettingWiring(TestCase):
+    def test_email_safe_mode_off_by_default(self):
+        # In the test environment EMAIL_SAFE_MODE is not set, so production
+        # (and any environment that hasn't explicitly opted in) must never
+        # accidentally inherit the allowlist backend.
+        self.assertFalse(getattr(settings, 'EMAIL_SAFE_MODE', False))
+        self.assertNotEqual(
+            'regluit.utils.safe_email_backend.AllowlistEmailBackend',
+            settings.EMAIL_BACKEND,
+        )


### PR DESCRIPTION
## TL;DR

**The problem:** when a staging server's database gets refreshed from a copy of production, it inherits every real user's real email address — and nothing stops it from actually mailing them (password resets, notices, whatever a human or script triggers while testing). **The fix:** an opt-in switch (off by default, zero effect on production) that redirects any staging email to a safe address instead, so testers can still see what would have gone out without a real person ever receiving it.

## Summary

- Part of #1238 (staging-refresh playbook). Found live on test.unglue.it 2026-08-31 while verifying #1237: nothing stops a staging/test box whose database has been refreshed from a prod snapshot from sending real transactional email (password resets, gift notices, campaign emails) to real users' real addresses -- confirmed by checking every settings module and `regluit-provisioning/group_vars/test`, none of which override `EMAIL_BACKEND`.
- Adds `utils/safe_email_backend.py`: `AllowlistEmailBackend` wraps the real backend and, per message, either passes it through unchanged (every recipient allowlisted) or redirects the whole thing to a configured catch-all, with the original recipients recorded in the body (subject stays generic -- see review history below) -- never silently drops (that's exactly what made #1164 and regluit-provisioning#22 harder to diagnose than necessary) and never silently delivers to an unknown address (refuses/raises if no redirect target is configured).
- Wired behind `EMAIL_SAFE_MODE` (env var, default off) in `settings/common.py` -- zero effect on production or any environment that hasn't explicitly opted in.

## Scope note

This is a backstop, not the primary fix. RY's stated preference (see #1238) is a synthetic/scrubbed test DB instead of a raw prod copy in the first place -- a bigger, separately-scoped follow-up. This backend is worth having regardless, for whatever a scrub script misses or a deliberate one-off raw-copy debugging session.

Deploying this to test.unglue.it (setting `EMAIL_SAFE_MODE=true` + an allowlist/redirect address there) is a separate, provisioning-side step, not done in this PR.

## Review history (worth reading if you're skimming past the label)

Three rounds of Codex review, each finding real bugs -- see the PR comment for the full breakdown. Highlights: a message subclass could have hidden a recipient from the allowlist check entirely (fixed by checking Django's own `recipients()` rather than `.to`/`.cc`/`.bcc`); the safety-net's own "refuse and log loudly" path was itself silently disabled by a Django logging-config gap; a malformed address value could fail open instead of closed; and the redirect notice went through two more passes before it stopped leaking recipient PII into logs/subjects. All fixed and re-verified live, not just re-tested.

## Test plan

- [x] `manage.py test libraryauth frontend utils` locally (Python 3.12.9 venv + disposable Docker MySQL 8) -- 74 tests, 3 failures + 2 errors, the same pre-existing baseline as origin/master (established while verifying #1237 in the same environment). Zero net-new failures across every commit in this PR.
- [x] 24 tests in `utils/tests.py` covering: allowlist matching (domain/address/case-insensitivity/empty-recipient/malformed-value/display-name), full pass-through, redirect on any non-allowlisted recipient (including mixed To lists, Cc, and Bcc), the `recipients()`-override bypass, context-manager support, refusal to send with no redirect target configured, the refusal log carrying no PII, and that `EMAIL_SAFE_MODE` defaults off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uv8CgcRqX4qjx9C74bVHj
