### PR TITLE
Release: login double-submit guard (#1241) + email-safety backend (#1239)

### DIFF
--- a/frontend/tests.py
+++ b/frontend/tests.py
@@ -444,11 +444,13 @@ class CampaignRetirementTests(TestCase):
 
 
 class LoginDoubleSubmitGuardTests(TestCase):
-    """Smoke tests pinning the #1240 double-submit guard in place.
+    """Tests pinning the #1240 double-submit guard in place.
 
-    The guard itself is client-side JS (static/js/sitewide1.js); these tests
-    assert the wiring that makes it effective: the login form posts to the
-    URL the guard watches, and every page loads the script that carries it.
+    The guard itself is client-side JS (static/js/sitewide1.js). Its behavior
+    is exercised by a dependency-free Node test (run here when node is
+    available); the Django-side tests assert the wiring that makes the guard
+    effective: the login form posts to the URL the guard watches, and every
+    page loads the script that carries it.
     """
 
     def test_login_page_wires_up_guard(self):
@@ -460,13 +462,21 @@ class LoginDoubleSubmitGuardTests(TestCase):
         # the login form still posts to the action the guard is scoped to
         self.assertIn('action="/accounts/superlogin/"', content)
 
-    def test_sitewide_js_contains_guard(self):
+    def test_guard_behavior_via_node(self):
         import os
-        path = os.path.join(
+        import shutil
+        import subprocess
+        import unittest
+        if not shutil.which("node"):
+            raise unittest.SkipTest("node not available")
+        test_js = os.path.join(
             os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-            "static", "js", "sitewide1.js",
+            "static", "js", "tests", "login_guard_test.js",
         )
-        with open(path) as f:
-            js = f.read()
-        self.assertIn("data-login-submitted", js)
-        self.assertIn("/accounts/superlogin/", js)
+        result = subprocess.run(
+            ["node", test_js], capture_output=True, text=True, timeout=30,
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            "guard behavioral tests failed:\n%s\n%s" % (result.stdout, result.stderr),
+        )

--- a/frontend/tests.py
+++ b/frontend/tests.py
@@ -441,3 +441,32 @@ class CampaignRetirementTests(TestCase):
         for work in (self.work, self.b2u_work):
             r = anon_client.get("/work/{}/".format(work.id))
             self.assertEqual(r.status_code, 200)
+
+
+class LoginDoubleSubmitGuardTests(TestCase):
+    """Smoke tests pinning the #1240 double-submit guard in place.
+
+    The guard itself is client-side JS (static/js/sitewide1.js); these tests
+    assert the wiring that makes it effective: the login form posts to the
+    URL the guard watches, and every page loads the script that carries it.
+    """
+
+    def test_login_page_wires_up_guard(self):
+        r = Client().get("/accounts/superlogin/")
+        self.assertEqual(r.status_code, 200)
+        content = r.content.decode()
+        # base.html loads the sitewide script that contains the guard
+        self.assertIn("/static/js/sitewide1.js", content)
+        # the login form still posts to the action the guard is scoped to
+        self.assertIn('action="/accounts/superlogin/"', content)
+
+    def test_sitewide_js_contains_guard(self):
+        import os
+        path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "static", "js", "sitewide1.js",
+        )
+        with open(path) as f:
+            js = f.read()
+        self.assertIn("data-login-submitted", js)
+        self.assertIn("/accounts/superlogin/", js)

--- a/settings/common.py
+++ b/settings/common.py
@@ -569,13 +569,25 @@ DOWNLOAD_LOGS_MAX = 499
 # (password resets, gift notices, campaign emails, ...) would deliver to
 # those real people. Off by default (empty string) so production, and any
 # environment that hasn't explicitly opted in, are unaffected.
+#
+# IMPORTANT if you're touching settings after this point: this must be the
+# LAST thing in the settings chain to set EMAIL_BACKEND. Any settings module
+# that does `from .common import *` and then re-sets EMAIL_BACKEND itself
+# (settings/spike.py already does exactly this, for an unrelated reason)
+# silently defeats this safety net. Verified 2026-08-31 that the actual
+# deploy template (regluit-provisioning/roles/regluit_prod/templates/
+# prod.py.j2, which is what test.unglue.it/unglue.it actually run as
+# regluit.settings.prod) does NOT re-set EMAIL_BACKEND after `from .common
+# import *` -- but that's an external file this repo doesn't control, so it
+# stays a live risk for any future change there. (CC review, 2026-08-31.)
+from regluit.utils.safe_email_backend import resolve_email_backend  # noqa: E402
+
 EMAIL_SAFE_MODE = os.environ.get('EMAIL_SAFE_MODE', '').strip().lower() in ('1', 'true', 'yes')
+SAFE_EMAIL_REAL_BACKEND, EMAIL_BACKEND = resolve_email_backend(
+    EMAIL_SAFE_MODE,
+    globals().get('EMAIL_BACKEND', 'django.core.mail.backends.smtp.EmailBackend'),
+)
 if EMAIL_SAFE_MODE:
-    SAFE_EMAIL_REAL_BACKEND = os.environ.get(
-        'SAFE_EMAIL_REAL_BACKEND',
-        globals().get('EMAIL_BACKEND', 'django.core.mail.backends.smtp.EmailBackend'),
-    )
-    EMAIL_BACKEND = 'regluit.utils.safe_email_backend.AllowlistEmailBackend'
     EMAIL_SAFE_MODE_ALLOWED_DOMAINS = os.environ.get('EMAIL_SAFE_MODE_ALLOWED_DOMAINS', '')
     EMAIL_SAFE_MODE_ALLOWED_ADDRESSES = os.environ.get('EMAIL_SAFE_MODE_ALLOWED_ADDRESSES', '')
     EMAIL_SAFE_MODE_REDIRECT_TO = os.environ.get('EMAIL_SAFE_MODE_REDIRECT_TO', '')

--- a/settings/common.py
+++ b/settings/common.py
@@ -562,3 +562,20 @@ STORAGES = {
 
 # we wond't record downloads for an ebook if their more than this in a month
 DOWNLOAD_LOGS_MAX = 499
+
+# Non-production email safety net (regluit#1238). A staging/test box whose
+# database has been refreshed from a copy of production holds real users'
+# real email addresses -- without this, its normal mail-sending code
+# (password resets, gift notices, campaign emails, ...) would deliver to
+# those real people. Off by default (empty string) so production, and any
+# environment that hasn't explicitly opted in, are unaffected.
+EMAIL_SAFE_MODE = os.environ.get('EMAIL_SAFE_MODE', '').strip().lower() in ('1', 'true', 'yes')
+if EMAIL_SAFE_MODE:
+    SAFE_EMAIL_REAL_BACKEND = os.environ.get(
+        'SAFE_EMAIL_REAL_BACKEND',
+        globals().get('EMAIL_BACKEND', 'django.core.mail.backends.smtp.EmailBackend'),
+    )
+    EMAIL_BACKEND = 'regluit.utils.safe_email_backend.AllowlistEmailBackend'
+    EMAIL_SAFE_MODE_ALLOWED_DOMAINS = os.environ.get('EMAIL_SAFE_MODE_ALLOWED_DOMAINS', '')
+    EMAIL_SAFE_MODE_ALLOWED_ADDRESSES = os.environ.get('EMAIL_SAFE_MODE_ALLOWED_ADDRESSES', '')
+    EMAIL_SAFE_MODE_REDIRECT_TO = os.environ.get('EMAIL_SAFE_MODE_REDIRECT_TO', '')

--- a/settings/common.py
+++ b/settings/common.py
@@ -265,6 +265,17 @@ LOGGING = {
             'handlers': ['downloads'],
             'propagate': False,
         },
+        # Without an explicit entry here, LOGGING's disable_existing_loggers
+        # (True, above) disables this logger outright the moment
+        # settings/common.py imports regluit.utils.safe_email_backend --
+        # verified live (Codex review round 2, 2026-08-31): its ERROR calls
+        # (the ones meant to make a Celery-swallowed send refusal visible;
+        # see EMAIL_SAFE_MODE below) silently did nothing without this.
+        'regluit.utils.safe_email_backend': {
+            'handlers': ['file'],
+            'level': 'ERROR',
+            'propagate': False,
+        },
         '': {
             'handlers': ['file'],
             'level': 'INFO',

--- a/static/js/sitewide1.js
+++ b/static/js/sitewide1.js
@@ -102,10 +102,14 @@ $j(document).ready(function() {
 // - The lock is module-global, not per form node: a page can hold more than
 //   one copy of the login form (standalone page + lightbox), and reopening
 //   the lightbox creates a fresh node. One login in flight locks them all.
-// - Capture phase blocks; bubble phase acquires. Acquiring on bubble means a
-//   submission some other handler already cancelled is not counted as "in
-//   flight"; blocking on capture means a locked submission is stopped before
-//   other handlers run.
+// - Everything happens in ONE document capture-phase listener, which runs
+//   before any target/ancestor handler can stopPropagation() the event away
+//   from us. The lock is acquired provisionally; a deferred (post-dispatch)
+//   check releases it again if some later handler cancelled the submission,
+//   so a cancelled submission never leaves the lock stuck.
+// - A blocked submission is stopped with stopImmediatePropagation() too, so
+//   downstream submit handlers cannot run side effects for it, and the
+//   blocked form's button is disabled so the state is visible.
 // - No timed unlock: unlocking on a timer while a slow login navigation is
 //   still pending would allow a resubmission with the stale token -- the
 //   exact bug this guards against. If navigation fails outright (network
@@ -122,37 +126,57 @@ $j(document).ready(function() {
         }
         var action = node.getAttribute('action') || '';
         try {
-            return new URL(action, window.location.href).pathname === LOGIN_PATH;
+            var url = new URL(action, window.location.href);
+            return url.origin === window.location.origin &&
+                url.pathname === LOGIN_PATH;
         } catch (err) {
             return false;
         }
     }
 
-    // Capture phase: block any login submission while one is in flight.
-    document.addEventListener('submit', function (event) {
-        if (loginSubmitInFlight && isLoginForm(event.target)) {
-            event.preventDefault();
-        }
-    }, true);
+    function submitButtonOf(form) {
+        return form.querySelector('input[type=submit], button[type=submit]');
+    }
 
-    // Bubble phase: acquire the lock, unless another handler cancelled
-    // this submission.
     document.addEventListener('submit', function (event) {
-        if (!isLoginForm(event.target) || event.defaultPrevented) {
+        var form = event.target;
+        if (!isLoginForm(form)) {
             return;
         }
+        if (loginSubmitInFlight) {
+            // A login POST is already pending: cancel this one outright and
+            // keep downstream handlers from acting on it.
+            event.preventDefault();
+            if (event.stopImmediatePropagation) {
+                event.stopImmediatePropagation();
+            } else {
+                event.stopPropagation();
+            }
+            var blockedButton = submitButtonOf(form);
+            if (blockedButton) {
+                blockedButton.disabled = true;
+            }
+            return;
+        }
+        // Acquire provisionally; confirm after the dispatch (and the
+        // browser's default action decision) has completed.
         loginSubmitInFlight = true;
-        var form = event.target;
-        // Disable the button only after this submission's form data has
-        // been captured (a disabled control would be dropped from it);
-        // purely visual feedback.
         window.setTimeout(function () {
-            var button = form.querySelector('input[type=submit], button[type=submit]');
+            if (event.defaultPrevented) {
+                // Some later handler cancelled this submission -- no POST
+                // happened, so release the lock.
+                loginSubmitInFlight = false;
+                return;
+            }
+            // The POST is really in flight. Disable the button only now,
+            // after the submission's form data has been captured (a
+            // disabled control would have been dropped from it).
+            var button = submitButtonOf(form);
             if (button) {
                 button.disabled = true;
             }
         }, 0);
-    });
+    }, true);
 
     window.addEventListener('pageshow', function (event) {
         if (event.persisted && loginSubmitInFlight) {

--- a/static/js/sitewide1.js
+++ b/static/js/sitewide1.js
@@ -83,3 +83,55 @@ $j(document).ready(function() {
         event.stopPropagation();
     });
 });
+
+// Guard the password login form against duplicate submissions (#1240).
+//
+// Password managers can auto-submit the login form right after autofilling
+// it. If the user then clicks "Sign in with Password" themselves, the second
+// POST carries the pre-login CSRF token -- Django rotates the CSRF cookie on
+// every successful login -- so the user sees a bare 403 page even though the
+// first POST already logged them in. First submission wins; any further
+// submission of the same form is ignored while the first is in flight.
+//
+// A document-level delegated listener is required (not an inline script in
+// login_form.html): the sign-in lightbox is injected via jQuery
+// .load(url + " #lightbox_content"), which strips <script> tags from the
+// loaded fragment.
+(function () {
+    document.addEventListener('submit', function (event) {
+        var form = event.target;
+        if (!form || !form.getAttribute) {
+            return;
+        }
+        var action = form.getAttribute('action') || '';
+        if (action.indexOf('/accounts/superlogin/') === -1) {
+            return;
+        }
+        // Another handler (or the browser) already cancelled this
+        // submission; don't count it as the one in flight.
+        if (event.defaultPrevented) {
+            return;
+        }
+        if (form.getAttribute('data-login-submitted') === 'true') {
+            event.preventDefault();
+            return;
+        }
+        form.setAttribute('data-login-submitted', 'true');
+        // Disable the button only after this submission's form data has been
+        // captured, purely as visual feedback. Re-enable after a while in
+        // case navigation never happens (e.g. network failure), so the form
+        // is not permanently stuck.
+        window.setTimeout(function () {
+            var button = form.querySelector('input[type=submit], button[type=submit]');
+            if (button) {
+                button.disabled = true;
+            }
+            window.setTimeout(function () {
+                form.removeAttribute('data-login-submitted');
+                if (button) {
+                    button.disabled = false;
+                }
+            }, 8000);
+        }, 0);
+    });
+})();

--- a/static/js/sitewide1.js
+++ b/static/js/sitewide1.js
@@ -84,6 +84,7 @@ $j(document).ready(function() {
     });
 });
 
+// #1240-guard-start (markers used by the Node behavioral test; keep them)
 // Guard the password login form against duplicate submissions (#1240).
 //
 // Password managers can auto-submit the login form right after autofilling
@@ -91,47 +92,72 @@ $j(document).ready(function() {
 // POST carries the pre-login CSRF token -- Django rotates the CSRF cookie on
 // every successful login -- so the user sees a bare 403 page even though the
 // first POST already logged them in. First submission wins; any further
-// submission of the same form is ignored while the first is in flight.
+// login submission is blocked while it is in flight.
 //
-// A document-level delegated listener is required (not an inline script in
-// login_form.html): the sign-in lightbox is injected via jQuery
-// .load(url + " #lightbox_content"), which strips <script> tags from the
-// loaded fragment.
+// Design notes:
+// - Document-level delegated listeners are required (not an inline script in
+//   login_form.html): the sign-in lightbox is injected via jQuery
+//   .load(url + " #lightbox_content"), which strips <script> tags from the
+//   loaded fragment.
+// - The lock is module-global, not per form node: a page can hold more than
+//   one copy of the login form (standalone page + lightbox), and reopening
+//   the lightbox creates a fresh node. One login in flight locks them all.
+// - Capture phase blocks; bubble phase acquires. Acquiring on bubble means a
+//   submission some other handler already cancelled is not counted as "in
+//   flight"; blocking on capture means a locked submission is stopped before
+//   other handlers run.
+// - No timed unlock: unlocking on a timer while a slow login navigation is
+//   still pending would allow a resubmission with the stale token -- the
+//   exact bug this guards against. If navigation fails outright (network
+//   down), the user reloads; the disabled button makes the state visible.
+// - bfcache: a page restored via back/forward still holds the lock and a
+//   pre-login CSRF token, so reload it for fresh state.
 (function () {
+    var LOGIN_PATH = '/accounts/superlogin/';
+    var loginSubmitInFlight = false;
+
+    function isLoginForm(node) {
+        if (!node || node.nodeName !== 'FORM' || !node.getAttribute) {
+            return false;
+        }
+        var action = node.getAttribute('action') || '';
+        try {
+            return new URL(action, window.location.href).pathname === LOGIN_PATH;
+        } catch (err) {
+            return false;
+        }
+    }
+
+    // Capture phase: block any login submission while one is in flight.
     document.addEventListener('submit', function (event) {
-        var form = event.target;
-        if (!form || !form.getAttribute) {
-            return;
-        }
-        var action = form.getAttribute('action') || '';
-        if (action.indexOf('/accounts/superlogin/') === -1) {
-            return;
-        }
-        // Another handler (or the browser) already cancelled this
-        // submission; don't count it as the one in flight.
-        if (event.defaultPrevented) {
-            return;
-        }
-        if (form.getAttribute('data-login-submitted') === 'true') {
+        if (loginSubmitInFlight && isLoginForm(event.target)) {
             event.preventDefault();
+        }
+    }, true);
+
+    // Bubble phase: acquire the lock, unless another handler cancelled
+    // this submission.
+    document.addEventListener('submit', function (event) {
+        if (!isLoginForm(event.target) || event.defaultPrevented) {
             return;
         }
-        form.setAttribute('data-login-submitted', 'true');
-        // Disable the button only after this submission's form data has been
-        // captured, purely as visual feedback. Re-enable after a while in
-        // case navigation never happens (e.g. network failure), so the form
-        // is not permanently stuck.
+        loginSubmitInFlight = true;
+        var form = event.target;
+        // Disable the button only after this submission's form data has
+        // been captured (a disabled control would be dropped from it);
+        // purely visual feedback.
         window.setTimeout(function () {
             var button = form.querySelector('input[type=submit], button[type=submit]');
             if (button) {
                 button.disabled = true;
             }
-            window.setTimeout(function () {
-                form.removeAttribute('data-login-submitted');
-                if (button) {
-                    button.disabled = false;
-                }
-            }, 8000);
         }, 0);
     });
+
+    window.addEventListener('pageshow', function (event) {
+        if (event.persisted && loginSubmitInFlight) {
+            window.location.reload();
+        }
+    });
 })();
+// #1240-guard-end

--- a/static/js/sitewide1.js
+++ b/static/js/sitewide1.js
@@ -95,25 +95,28 @@ $j(document).ready(function() {
 // login submission is blocked while it is in flight.
 //
 // Design notes:
-// - Document-level delegated listeners are required (not an inline script in
+// - Document/window-level delegation is required (not an inline script in
 //   login_form.html): the sign-in lightbox is injected via jQuery
 //   .load(url + " #lightbox_content"), which strips <script> tags from the
 //   loaded fragment.
+// - The listener sits on WINDOW in the capture phase -- the earliest point
+//   on the propagation path -- so no document/target/ancestor handler can
+//   stopPropagation() the event away from the guard.
 // - The lock is module-global, not per form node: a page can hold more than
 //   one copy of the login form (standalone page + lightbox), and reopening
 //   the lightbox creates a fresh node. One login in flight locks them all.
-// - Everything happens in ONE document capture-phase listener, which runs
-//   before any target/ancestor handler can stopPropagation() the event away
-//   from us. The lock is acquired provisionally; a deferred (post-dispatch)
-//   check releases it again if some later handler cancelled the submission,
-//   so a cancelled submission never leaves the lock stuck.
-// - A blocked submission is stopped with stopImmediatePropagation() too, so
-//   downstream submit handlers cannot run side effects for it, and the
-//   blocked form's button is disabled so the state is visible.
-// - No timed unlock: unlocking on a timer while a slow login navigation is
-//   still pending would allow a resubmission with the stale token -- the
-//   exact bug this guards against. If navigation fails outright (network
-//   down), the user reloads; the disabled button makes the state visible.
+// - FAIL-CLOSED by design: once acquired, the lock is held until navigation
+//   or bfcache restore. A hypothetical future handler that cancels (or
+//   cancel-and-replaces) a login submission would leave the lock held --
+//   a visibly stuck form fixed by reload -- rather than risk releasing it
+//   while a POST is in flight, which would recreate the CSRF bug this
+//   guards against. (No such handler exists in this codebase today; the
+//   synchronous defaultPrevented check below covers anything that cancelled
+//   the event before the guard saw it.)
+// - A blocked submission is cancelled with preventDefault +
+//   stopImmediatePropagation, so downstream submit handlers cannot run side
+//   effects for it, and the button that triggered it is disabled so the
+//   state is visible.
 // - bfcache: a page restored via back/forward still holds the lock and a
 //   pre-login CSRF token, so reload it for fresh state.
 (function () {
@@ -134,44 +137,40 @@ $j(document).ready(function() {
         }
     }
 
-    function submitButtonOf(form) {
-        return form.querySelector('input[type=submit], button[type=submit]');
+    // The control that actually triggered the submission when the browser
+    // reports it (event.submitter); the form's first submit control as a
+    // fallback (implicit Enter-key submission, older engines).
+    function buttonFor(event, form) {
+        return event.submitter ||
+            form.querySelector('input[type=submit], button[type=submit]');
     }
 
-    document.addEventListener('submit', function (event) {
+    window.addEventListener('submit', function (event) {
         var form = event.target;
         if (!isLoginForm(form)) {
             return;
         }
+        if (event.defaultPrevented) {
+            // Cancelled before the guard saw it; no POST will happen.
+            return;
+        }
         if (loginSubmitInFlight) {
             // A login POST is already pending: cancel this one outright and
-            // keep downstream handlers from acting on it.
+            // keep every later handler from acting on it.
             event.preventDefault();
-            if (event.stopImmediatePropagation) {
-                event.stopImmediatePropagation();
-            } else {
-                event.stopPropagation();
-            }
-            var blockedButton = submitButtonOf(form);
+            event.stopImmediatePropagation();
+            var blockedButton = buttonFor(event, form);
             if (blockedButton) {
                 blockedButton.disabled = true;
             }
             return;
         }
-        // Acquire provisionally; confirm after the dispatch (and the
-        // browser's default action decision) has completed.
         loginSubmitInFlight = true;
+        // Disable the button only after this submission's form data has
+        // been captured (a disabled control would be dropped from it);
+        // purely visual feedback.
         window.setTimeout(function () {
-            if (event.defaultPrevented) {
-                // Some later handler cancelled this submission -- no POST
-                // happened, so release the lock.
-                loginSubmitInFlight = false;
-                return;
-            }
-            // The POST is really in flight. Disable the button only now,
-            // after the submission's form data has been captured (a
-            // disabled control would have been dropped from it).
-            var button = submitButtonOf(form);
+            var button = buttonFor(event, form);
             if (button) {
                 button.disabled = true;
             }

--- a/static/js/tests/login_guard_test.js
+++ b/static/js/tests/login_guard_test.js
@@ -6,11 +6,13 @@
 //
 // The guard is extracted from static/js/sitewide1.js between the
 // `#1240-guard-start` / `#1240-guard-end` markers and evaluated against
-// minimal document/window/form fakes. The dispatch fake models real DOM
-// event propagation for a document-level listener: document capture phase,
-// then target listeners, then document bubble phase, honoring
-// preventDefault / stopPropagation / stopImmediatePropagation, with the
-// browser's default action decided after dispatch completes.
+// minimal window/document/form fakes. The dispatch fake models real DOM
+// event propagation for a submit event: window capture, document capture,
+// target listeners, document bubble, window bubble -- honoring
+// preventDefault / stopPropagation / stopImmediatePropagation. (The
+// browser's default-action decision happens after dispatch; the guard is
+// deliberately fail-closed, so the tests assert lock retention, not
+// rollback.)
 
 'use strict';
 
@@ -30,9 +32,10 @@ const guardSource = source.slice(start, end);
 
 // ---- minimal DOM fakes ----------------------------------------------------
 
-function makeEvent(target) {
+function makeEvent(target, submitter) {
     return {
         target: target,
+        submitter: submitter || null,
         defaultPrevented: false,
         _stopProp: false,
         _stopImmediate: false,
@@ -58,6 +61,7 @@ function makeForm(action) {
 }
 
 function makeHarness() {
+    const winListeners = { capture: [], bubble: [] };
     const docListeners = { capture: [], bubble: [] };
     const windowListeners = {};
     const timeouts = [];
@@ -65,7 +69,7 @@ function makeHarness() {
 
     const documentFake = {
         addEventListener(type, fn, capture) {
-            assert.strictEqual(type, 'submit', 'guard only listens for submit on document');
+            assert.strictEqual(type, 'submit', 'only submit listeners expected on document');
             docListeners[capture ? 'capture' : 'bubble'].push(fn);
         },
     };
@@ -76,7 +80,11 @@ function makeHarness() {
             reload() { reloads += 1; },
         },
         setTimeout(fn, ms) { timeouts.push(fn); return timeouts.length; },
-        addEventListener(type, fn) {
+        addEventListener(type, fn, capture) {
+            if (type === 'submit') {
+                winListeners[capture ? 'capture' : 'bubble'].push(fn);
+                return;
+            }
             (windowListeners[type] = windowListeners[type] || []).push(fn);
         },
     };
@@ -88,16 +96,24 @@ function makeHarness() {
     });
 
     return {
-        // Model a real submit dispatch: document capture listeners, then
-        // target listeners, then document bubble listeners. Returns
-        // { event, submitted } where `submitted` is the browser's
-        // default-action decision made after dispatch.
-        dispatchSubmit(form, { targetHandlers = [], docBubbleHandlers = [] } = {}) {
-            const event = makeEvent(form);
+        // Model a real submit dispatch: window capture, document capture,
+        // target, document bubble, window bubble. Returns { event,
+        // submitted } where `submitted` reflects the default-action
+        // decision (not cancelled).
+        dispatchSubmit(form, {
+            submitter = null,
+            preGuardHandlers = [],   // window-capture listeners registered BEFORE sitewide1.js
+            docCaptureHandlers = [],
+            targetHandlers = [],
+            docBubbleHandlers = [],
+        } = {}) {
+            const event = makeEvent(form, submitter);
             const phases = [
-                docListeners.capture,
+                preGuardHandlers.concat(winListeners.capture),
+                docListeners.capture.concat(docCaptureHandlers),
                 targetHandlers,
                 docListeners.bubble.concat(docBubbleHandlers),
+                winListeners.bubble,
             ];
             outer:
             for (const phase of phases) {
@@ -143,23 +159,49 @@ const tests = {
         assert.strictEqual(second.submitted, false, 'other login form nodes must be blocked too');
     },
 
-    'a LATER handler cancelling the submission releases the lock'() {
-        // Round-2 finding 1: sitewide1.js loads first, so other document
-        // listeners run after the guard. If one of them preventDefault()s,
-        // no POST happens and the lock must not stay stuck.
+    'fail-closed: a later handler cancelling the submission leaves the lock held'() {
+        // Round-3 finding 1: a timer-time defaultPrevented check cannot
+        // distinguish "cancelled" from "cancelled and replaced by
+        // form.submit()", so the guard deliberately retains the lock.
         const h = makeHarness();
         h.dispatchSubmit(makeForm(LOGIN_ACTION), {
             docBubbleHandlers: [(e) => e.preventDefault()],
         });
-        h.flushTimeouts(); // deferred rollback runs
+        h.flushTimeouts();
         const retry = h.dispatchSubmit(makeForm(LOGIN_ACTION));
-        assert.strictEqual(retry.submitted, true,
-            'after a cancelled submission, a real retry must still be allowed');
+        assert.strictEqual(retry.submitted, false,
+            'lock must be retained (fail-closed) after a late cancellation');
+    },
+
+    'a submission cancelled BEFORE the guard sees it does not acquire the lock'() {
+        // An earlier window-capture listener (registered before sitewide1.js
+        // loaded) cancels the event; the guard's synchronous defaultPrevented
+        // check must skip acquisition, since no POST will happen.
+        const h = makeHarness();
+        const cancelled = h.dispatchSubmit(makeForm(LOGIN_ACTION), {
+            preGuardHandlers: [(e) => e.preventDefault()],
+        });
+        assert.strictEqual(cancelled.submitted, false);
+        h.flushTimeouts();
+        const real = h.dispatchSubmit(makeForm(LOGIN_ACTION));
+        assert.strictEqual(real.submitted, true,
+            'a later real submission must still be allowed');
+    },
+
+    'document-capture stopPropagation cannot bypass lock acquisition'() {
+        // Round-3 finding 3 analogue: the guard sits on window capture,
+        // ahead of document capture, target, and bubble handlers.
+        const h = makeHarness();
+        const first = h.dispatchSubmit(makeForm(LOGIN_ACTION), {
+            docCaptureHandlers: [(e) => e.stopPropagation()],
+        });
+        assert.strictEqual(first.submitted, true, 'first POST proceeds');
+        h.flushTimeouts();
+        const second = h.dispatchSubmit(makeForm(LOGIN_ACTION));
+        assert.strictEqual(second.submitted, false, 'lock was still acquired');
     },
 
     'target stopPropagation() cannot bypass lock acquisition'() {
-        // Round-2 finding 2: acquisition happens in document capture, which
-        // runs before target handlers can stop propagation.
         const h = makeHarness();
         const first = h.dispatchSubmit(makeForm(LOGIN_ACTION), {
             targetHandlers: [(e) => e.stopPropagation()],
@@ -171,13 +213,12 @@ const tests = {
     },
 
     'a blocked submission stops downstream handlers'() {
-        // Round-2 finding 3: preventDefault alone would still let target
-        // handlers run side effects (AJAX, form.submit()).
         const h = makeHarness();
         h.dispatchSubmit(makeForm(LOGIN_ACTION));
         h.flushTimeouts();
         let downstreamRan = false;
         const blocked = h.dispatchSubmit(makeForm(LOGIN_ACTION), {
+            docCaptureHandlers: [() => { downstreamRan = true; }],
             targetHandlers: [() => { downstreamRan = true; }],
         });
         assert.strictEqual(blocked.submitted, false);
@@ -186,8 +227,6 @@ const tests = {
     },
 
     'a blocked form gets its button disabled (visible stuck-state)'() {
-        // Round-2 finding 4: a fresh lightbox form clicked while locked
-        // must not look silently ignorable.
         const h = makeHarness();
         h.dispatchSubmit(makeForm(LOGIN_ACTION));
         h.flushTimeouts();
@@ -195,6 +234,18 @@ const tests = {
         h.dispatchSubmit(freshForm);
         assert.strictEqual(freshForm._button.disabled, true,
             'blocked form button must be disabled immediately');
+    },
+
+    'the actual submitter control is preferred over the first submit button'() {
+        // Round-3 finding 5.
+        const h = makeHarness();
+        const form = makeForm(LOGIN_ACTION);
+        const submitter = { disabled: false };
+        h.dispatchSubmit(form, { submitter: submitter });
+        h.flushTimeouts();
+        assert.strictEqual(submitter.disabled, true, 'event.submitter must be disabled');
+        assert.strictEqual(form._button.disabled, false,
+            'querySelector fallback must not fire when submitter is known');
     },
 
     'unrelated forms are never touched'() {
@@ -227,7 +278,6 @@ const tests = {
     },
 
     'cross-origin action with the same path is not ours'() {
-        // Round-2 finding 5.
         const h = makeHarness();
         h.dispatchSubmit(makeForm(LOGIN_ACTION));
         h.flushTimeouts();
@@ -244,15 +294,6 @@ const tests = {
             'button must not be disabled synchronously (it would drop from form data)');
         h.flushTimeouts();
         assert.strictEqual(form._button.disabled, true, 'button disabled as visual feedback');
-    },
-
-    'cancelled submission does not disable the button'() {
-        const h = makeHarness();
-        const form = makeForm(LOGIN_ACTION);
-        h.dispatchSubmit(form, { docBubbleHandlers: [(e) => e.preventDefault()] });
-        h.flushTimeouts();
-        assert.strictEqual(form._button.disabled, false,
-            'no POST happened; the form must stay usable');
     },
 
     'bfcache restore with a login in flight reloads the page'() {

--- a/static/js/tests/login_guard_test.js
+++ b/static/js/tests/login_guard_test.js
@@ -1,0 +1,207 @@
+// Behavioral test for the #1240 login double-submit guard.
+//
+// Dependency-free: run with `node static/js/tests/login_guard_test.js`.
+// Exits 0 on success, 1 on failure. Also wired into the Django suite
+// (frontend/tests.py LoginDoubleSubmitGuardTests) when node is available.
+//
+// The guard is extracted from static/js/sitewide1.js between the
+// `#1240-guard-start` / `#1240-guard-end` markers and evaluated against
+// minimal document/window/form fakes that model DOM event dispatch
+// (capture phase, then bubble phase, with preventDefault semantics).
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+// ---- extract the guard ----------------------------------------------------
+
+const sitewidePath = path.join(__dirname, '..', 'sitewide1.js');
+const source = fs.readFileSync(sitewidePath, 'utf8');
+const start = source.indexOf('// #1240-guard-start');
+const end = source.indexOf('// #1240-guard-end');
+assert.ok(start !== -1 && end > start, 'guard markers present in sitewide1.js');
+const guardSource = source.slice(start, end);
+
+// ---- minimal DOM fakes ----------------------------------------------------
+
+function makeEvent(target) {
+    return {
+        target: target,
+        defaultPrevented: false,
+        preventDefault() { this.defaultPrevented = true; },
+    };
+}
+
+function makeButton() {
+    return { disabled: false };
+}
+
+function makeForm(action) {
+    const attrs = { action: action };
+    const button = makeButton();
+    return {
+        nodeName: 'FORM',
+        _button: button,
+        getAttribute(name) {
+            return Object.prototype.hasOwnProperty.call(attrs, name) ? attrs[name] : null;
+        },
+        setAttribute(name, value) { attrs[name] = String(value); },
+        removeAttribute(name) { delete attrs[name]; },
+        querySelector() { return button; },
+    };
+}
+
+function makeHarness() {
+    const listeners = { capture: [], bubble: [] };
+    const windowListeners = {};
+    const timeouts = [];
+    let reloads = 0;
+
+    const documentFake = {
+        addEventListener(type, fn, capture) {
+            assert.strictEqual(type, 'submit', 'guard only listens for submit on document');
+            listeners[capture ? 'capture' : 'bubble'].push(fn);
+        },
+    };
+    const windowFake = {
+        location: {
+            href: 'https://unglue.it/',
+            reload() { reloads += 1; },
+        },
+        setTimeout(fn, ms) { timeouts.push(fn); return timeouts.length; },
+        addEventListener(type, fn) {
+            (windowListeners[type] = windowListeners[type] || []).push(fn);
+        },
+    };
+
+    vm.runInNewContext(guardSource, {
+        document: documentFake,
+        window: windowFake,
+        URL: URL,
+    });
+
+    return {
+        // Dispatch like a browser would for a document-level submit:
+        // capture listeners first, then bubble listeners. `preCancelled`
+        // models some other handler (e.g. an inline onsubmit returning
+        // false) having cancelled the event before the guard's bubble
+        // listener runs.
+        dispatchSubmit(form, { preCancelled = false } = {}) {
+            const event = makeEvent(form);
+            listeners.capture.forEach((fn) => fn(event));
+            if (preCancelled) event.preventDefault();
+            listeners.bubble.forEach((fn) => fn(event));
+            return event;
+        },
+        firePageshow(persisted) {
+            (windowListeners.pageshow || []).forEach((fn) => fn({ persisted: persisted }));
+        },
+        flushTimeouts() {
+            while (timeouts.length) timeouts.shift()();
+        },
+        get reloads() { return reloads; },
+    };
+}
+
+const LOGIN_ACTION = '/accounts/superlogin/';
+
+// ---- tests ----------------------------------------------------------------
+
+const tests = {
+    'first submission is allowed and acquires the lock'() {
+        const h = makeHarness();
+        const form = makeForm(LOGIN_ACTION);
+        const e1 = h.dispatchSubmit(form);
+        assert.strictEqual(e1.defaultPrevented, false, 'first submit must go through');
+        const e2 = h.dispatchSubmit(form);
+        assert.strictEqual(e2.defaultPrevented, true, 'second submit must be blocked');
+    },
+
+    'lock is global across distinct login form nodes'() {
+        const h = makeHarness();
+        h.dispatchSubmit(makeForm(LOGIN_ACTION));
+        const e2 = h.dispatchSubmit(makeForm(LOGIN_ACTION)); // fresh node (e.g. reopened lightbox)
+        assert.strictEqual(e2.defaultPrevented, true, 'other login form nodes must be blocked too');
+    },
+
+    'a submission cancelled by another handler does not acquire the lock'() {
+        const h = makeHarness();
+        h.dispatchSubmit(makeForm(LOGIN_ACTION), { preCancelled: true });
+        const e2 = h.dispatchSubmit(makeForm(LOGIN_ACTION));
+        assert.strictEqual(e2.defaultPrevented, false,
+            'a later real submission must still be allowed');
+    },
+
+    'unrelated forms are never touched'() {
+        const h = makeHarness();
+        h.dispatchSubmit(makeForm(LOGIN_ACTION)); // lock held
+        const other = h.dispatchSubmit(makeForm('/accounts/register/'));
+        assert.strictEqual(other.defaultPrevented, false, 'non-login form must not be blocked');
+    },
+
+    'action matching is by pathname, not substring'() {
+        const h = makeHarness();
+        h.dispatchSubmit(makeForm(LOGIN_ACTION)); // lock held
+        const smuggled = h.dispatchSubmit(
+            makeForm('/feedback/?page=/accounts/superlogin/'));
+        assert.strictEqual(smuggled.defaultPrevented, false,
+            'querystring mention of the login path must not match');
+        const withNext = h.dispatchSubmit(
+            makeForm('/accounts/superlogin/?next=/work/1/'));
+        assert.strictEqual(withNext.defaultPrevented, true,
+            'login action with querystring must match');
+    },
+
+    'absolute-URL action on our origin matches'() {
+        const h = makeHarness();
+        const e1 = h.dispatchSubmit(makeForm('https://unglue.it/accounts/superlogin/'));
+        assert.strictEqual(e1.defaultPrevented, false);
+        const e2 = h.dispatchSubmit(makeForm(LOGIN_ACTION));
+        assert.strictEqual(e2.defaultPrevented, true, 'lock acquired via absolute action');
+    },
+
+    'submit button is disabled only after form data capture (async)'() {
+        const h = makeHarness();
+        const form = makeForm(LOGIN_ACTION);
+        h.dispatchSubmit(form);
+        assert.strictEqual(form._button.disabled, false,
+            'button must not be disabled synchronously (it would drop from form data)');
+        h.flushTimeouts();
+        assert.strictEqual(form._button.disabled, true, 'button disabled as visual feedback');
+    },
+
+    'bfcache restore with a login in flight reloads the page'() {
+        const h = makeHarness();
+        h.dispatchSubmit(makeForm(LOGIN_ACTION));
+        h.firePageshow(true);
+        assert.strictEqual(h.reloads, 1, 'persisted pageshow with lock held must reload');
+    },
+
+    'normal pageshow or no lock does not reload'() {
+        const h = makeHarness();
+        h.firePageshow(true);   // no login in flight
+        h.firePageshow(false);  // normal load
+        h.dispatchSubmit(makeForm(LOGIN_ACTION));
+        h.firePageshow(false);  // normal load with lock held
+        assert.strictEqual(h.reloads, 0);
+    },
+};
+
+let failures = 0;
+for (const [name, fn] of Object.entries(tests)) {
+    try {
+        fn();
+        console.log('ok - ' + name);
+    } catch (err) {
+        failures += 1;
+        console.error('FAIL - ' + name + ': ' + err.message);
+    }
+}
+if (failures) {
+    console.error(failures + ' test(s) failed');
+    process.exit(1);
+}
+console.log('all ' + Object.keys(tests).length + ' guard tests passed');

--- a/static/js/tests/login_guard_test.js
+++ b/static/js/tests/login_guard_test.js
@@ -6,8 +6,11 @@
 //
 // The guard is extracted from static/js/sitewide1.js between the
 // `#1240-guard-start` / `#1240-guard-end` markers and evaluated against
-// minimal document/window/form fakes that model DOM event dispatch
-// (capture phase, then bubble phase, with preventDefault semantics).
+// minimal document/window/form fakes. The dispatch fake models real DOM
+// event propagation for a document-level listener: document capture phase,
+// then target listeners, then document bubble phase, honoring
+// preventDefault / stopPropagation / stopImmediatePropagation, with the
+// browser's default action decided after dispatch completes.
 
 'use strict';
 
@@ -31,17 +34,17 @@ function makeEvent(target) {
     return {
         target: target,
         defaultPrevented: false,
+        _stopProp: false,
+        _stopImmediate: false,
         preventDefault() { this.defaultPrevented = true; },
+        stopPropagation() { this._stopProp = true; },
+        stopImmediatePropagation() { this._stopProp = true; this._stopImmediate = true; },
     };
-}
-
-function makeButton() {
-    return { disabled: false };
 }
 
 function makeForm(action) {
     const attrs = { action: action };
-    const button = makeButton();
+    const button = { disabled: false };
     return {
         nodeName: 'FORM',
         _button: button,
@@ -55,7 +58,7 @@ function makeForm(action) {
 }
 
 function makeHarness() {
-    const listeners = { capture: [], bubble: [] };
+    const docListeners = { capture: [], bubble: [] };
     const windowListeners = {};
     const timeouts = [];
     let reloads = 0;
@@ -63,12 +66,13 @@ function makeHarness() {
     const documentFake = {
         addEventListener(type, fn, capture) {
             assert.strictEqual(type, 'submit', 'guard only listens for submit on document');
-            listeners[capture ? 'capture' : 'bubble'].push(fn);
+            docListeners[capture ? 'capture' : 'bubble'].push(fn);
         },
     };
     const windowFake = {
         location: {
             href: 'https://unglue.it/',
+            origin: 'https://unglue.it',
             reload() { reloads += 1; },
         },
         setTimeout(fn, ms) { timeouts.push(fn); return timeouts.length; },
@@ -84,17 +88,26 @@ function makeHarness() {
     });
 
     return {
-        // Dispatch like a browser would for a document-level submit:
-        // capture listeners first, then bubble listeners. `preCancelled`
-        // models some other handler (e.g. an inline onsubmit returning
-        // false) having cancelled the event before the guard's bubble
-        // listener runs.
-        dispatchSubmit(form, { preCancelled = false } = {}) {
+        // Model a real submit dispatch: document capture listeners, then
+        // target listeners, then document bubble listeners. Returns
+        // { event, submitted } where `submitted` is the browser's
+        // default-action decision made after dispatch.
+        dispatchSubmit(form, { targetHandlers = [], docBubbleHandlers = [] } = {}) {
             const event = makeEvent(form);
-            listeners.capture.forEach((fn) => fn(event));
-            if (preCancelled) event.preventDefault();
-            listeners.bubble.forEach((fn) => fn(event));
-            return event;
+            const phases = [
+                docListeners.capture,
+                targetHandlers,
+                docListeners.bubble.concat(docBubbleHandlers),
+            ];
+            outer:
+            for (const phase of phases) {
+                for (const fn of phase) {
+                    fn(event);
+                    if (event._stopImmediate) break outer;
+                }
+                if (event._stopProp) break;
+            }
+            return { event, submitted: !event.defaultPrevented };
         },
         firePageshow(persisted) {
             (windowListeners.pageshow || []).forEach((fn) => fn({ persisted: persisted }));
@@ -114,53 +127,113 @@ const tests = {
     'first submission is allowed and acquires the lock'() {
         const h = makeHarness();
         const form = makeForm(LOGIN_ACTION);
-        const e1 = h.dispatchSubmit(form);
-        assert.strictEqual(e1.defaultPrevented, false, 'first submit must go through');
-        const e2 = h.dispatchSubmit(form);
-        assert.strictEqual(e2.defaultPrevented, true, 'second submit must be blocked');
+        const first = h.dispatchSubmit(form);
+        assert.strictEqual(first.submitted, true, 'first submit must go through');
+        h.flushTimeouts();
+        const second = h.dispatchSubmit(form);
+        assert.strictEqual(second.submitted, false, 'second submit must be blocked');
     },
 
     'lock is global across distinct login form nodes'() {
         const h = makeHarness();
         h.dispatchSubmit(makeForm(LOGIN_ACTION));
-        const e2 = h.dispatchSubmit(makeForm(LOGIN_ACTION)); // fresh node (e.g. reopened lightbox)
-        assert.strictEqual(e2.defaultPrevented, true, 'other login form nodes must be blocked too');
+        h.flushTimeouts();
+        // fresh node, e.g. a reopened lightbox
+        const second = h.dispatchSubmit(makeForm(LOGIN_ACTION));
+        assert.strictEqual(second.submitted, false, 'other login form nodes must be blocked too');
     },
 
-    'a submission cancelled by another handler does not acquire the lock'() {
+    'a LATER handler cancelling the submission releases the lock'() {
+        // Round-2 finding 1: sitewide1.js loads first, so other document
+        // listeners run after the guard. If one of them preventDefault()s,
+        // no POST happens and the lock must not stay stuck.
         const h = makeHarness();
-        h.dispatchSubmit(makeForm(LOGIN_ACTION), { preCancelled: true });
-        const e2 = h.dispatchSubmit(makeForm(LOGIN_ACTION));
-        assert.strictEqual(e2.defaultPrevented, false,
-            'a later real submission must still be allowed');
+        h.dispatchSubmit(makeForm(LOGIN_ACTION), {
+            docBubbleHandlers: [(e) => e.preventDefault()],
+        });
+        h.flushTimeouts(); // deferred rollback runs
+        const retry = h.dispatchSubmit(makeForm(LOGIN_ACTION));
+        assert.strictEqual(retry.submitted, true,
+            'after a cancelled submission, a real retry must still be allowed');
+    },
+
+    'target stopPropagation() cannot bypass lock acquisition'() {
+        // Round-2 finding 2: acquisition happens in document capture, which
+        // runs before target handlers can stop propagation.
+        const h = makeHarness();
+        const first = h.dispatchSubmit(makeForm(LOGIN_ACTION), {
+            targetHandlers: [(e) => e.stopPropagation()],
+        });
+        assert.strictEqual(first.submitted, true, 'first POST proceeds');
+        h.flushTimeouts();
+        const second = h.dispatchSubmit(makeForm(LOGIN_ACTION));
+        assert.strictEqual(second.submitted, false, 'lock was still acquired');
+    },
+
+    'a blocked submission stops downstream handlers'() {
+        // Round-2 finding 3: preventDefault alone would still let target
+        // handlers run side effects (AJAX, form.submit()).
+        const h = makeHarness();
+        h.dispatchSubmit(makeForm(LOGIN_ACTION));
+        h.flushTimeouts();
+        let downstreamRan = false;
+        const blocked = h.dispatchSubmit(makeForm(LOGIN_ACTION), {
+            targetHandlers: [() => { downstreamRan = true; }],
+        });
+        assert.strictEqual(blocked.submitted, false);
+        assert.strictEqual(downstreamRan, false,
+            'downstream handlers must not run for a blocked submission');
+    },
+
+    'a blocked form gets its button disabled (visible stuck-state)'() {
+        // Round-2 finding 4: a fresh lightbox form clicked while locked
+        // must not look silently ignorable.
+        const h = makeHarness();
+        h.dispatchSubmit(makeForm(LOGIN_ACTION));
+        h.flushTimeouts();
+        const freshForm = makeForm(LOGIN_ACTION);
+        h.dispatchSubmit(freshForm);
+        assert.strictEqual(freshForm._button.disabled, true,
+            'blocked form button must be disabled immediately');
     },
 
     'unrelated forms are never touched'() {
         const h = makeHarness();
-        h.dispatchSubmit(makeForm(LOGIN_ACTION)); // lock held
+        h.dispatchSubmit(makeForm(LOGIN_ACTION));
+        h.flushTimeouts();
         const other = h.dispatchSubmit(makeForm('/accounts/register/'));
-        assert.strictEqual(other.defaultPrevented, false, 'non-login form must not be blocked');
+        assert.strictEqual(other.submitted, true, 'non-login form must not be blocked');
     },
 
     'action matching is by pathname, not substring'() {
         const h = makeHarness();
-        h.dispatchSubmit(makeForm(LOGIN_ACTION)); // lock held
-        const smuggled = h.dispatchSubmit(
-            makeForm('/feedback/?page=/accounts/superlogin/'));
-        assert.strictEqual(smuggled.defaultPrevented, false,
+        h.dispatchSubmit(makeForm(LOGIN_ACTION));
+        h.flushTimeouts();
+        const smuggled = h.dispatchSubmit(makeForm('/feedback/?page=/accounts/superlogin/'));
+        assert.strictEqual(smuggled.submitted, true,
             'querystring mention of the login path must not match');
-        const withNext = h.dispatchSubmit(
-            makeForm('/accounts/superlogin/?next=/work/1/'));
-        assert.strictEqual(withNext.defaultPrevented, true,
+        const withNext = h.dispatchSubmit(makeForm('/accounts/superlogin/?next=/work/1/'));
+        assert.strictEqual(withNext.submitted, false,
             'login action with querystring must match');
     },
 
     'absolute-URL action on our origin matches'() {
         const h = makeHarness();
-        const e1 = h.dispatchSubmit(makeForm('https://unglue.it/accounts/superlogin/'));
-        assert.strictEqual(e1.defaultPrevented, false);
-        const e2 = h.dispatchSubmit(makeForm(LOGIN_ACTION));
-        assert.strictEqual(e2.defaultPrevented, true, 'lock acquired via absolute action');
+        const first = h.dispatchSubmit(makeForm('https://unglue.it/accounts/superlogin/'));
+        assert.strictEqual(first.submitted, true);
+        h.flushTimeouts();
+        const second = h.dispatchSubmit(makeForm(LOGIN_ACTION));
+        assert.strictEqual(second.submitted, false, 'lock acquired via absolute action');
+    },
+
+    'cross-origin action with the same path is not ours'() {
+        // Round-2 finding 5.
+        const h = makeHarness();
+        h.dispatchSubmit(makeForm(LOGIN_ACTION));
+        h.flushTimeouts();
+        const foreign = h.dispatchSubmit(makeForm('https://evil.example/accounts/superlogin/'));
+        assert.strictEqual(foreign.submitted, true,
+            'a cross-origin form must not be treated as our login form');
     },
 
     'submit button is disabled only after form data capture (async)'() {
@@ -173,9 +246,19 @@ const tests = {
         assert.strictEqual(form._button.disabled, true, 'button disabled as visual feedback');
     },
 
+    'cancelled submission does not disable the button'() {
+        const h = makeHarness();
+        const form = makeForm(LOGIN_ACTION);
+        h.dispatchSubmit(form, { docBubbleHandlers: [(e) => e.preventDefault()] });
+        h.flushTimeouts();
+        assert.strictEqual(form._button.disabled, false,
+            'no POST happened; the form must stay usable');
+    },
+
     'bfcache restore with a login in flight reloads the page'() {
         const h = makeHarness();
         h.dispatchSubmit(makeForm(LOGIN_ACTION));
+        h.flushTimeouts();
         h.firePageshow(true);
         assert.strictEqual(h.reloads, 1, 'persisted pageshow with lock held must reload');
     },
@@ -185,6 +268,7 @@ const tests = {
         h.firePageshow(true);   // no login in flight
         h.firePageshow(false);  // normal load
         h.dispatchSubmit(makeForm(LOGIN_ACTION));
+        h.flushTimeouts();
         h.firePageshow(false);  // normal load with lock held
         assert.strictEqual(h.reloads, 0);
     },

--- a/utils/safe_email_backend.py
+++ b/utils/safe_email_backend.py
@@ -156,16 +156,18 @@ class AllowlistEmailBackend(BaseEmailBackend):
             # Log at ERROR (not just raise) because Celery's send_mail_task
             # swallows exceptions from backends without re-raising, which
             # would otherwise make this look like a silently dropped
-            # email. Deliberately does NOT log the actual recipient
-            # addresses -- that would recreate the exact PII-in-logs
-            # exposure the subject/body split above exists to avoid
-            # (Codex review round 2, 2026-08-31); a count is enough to
-            # know something needs fixing.
+            # email. Deliberately logs neither the actual recipient
+            # addresses nor the subject -- a first pass here logged the
+            # subject as a "safe" identifier, but a subject can itself
+            # carry PII (e.g. "Password reset for real@example.com"),
+            # recreating the exact exposure the subject/body split above
+            # exists to avoid (Codex review round 3, 2026-08-31). A bare
+            # count is enough to know something needs fixing.
             logger.error(
-                "AllowlistEmailBackend: refusing to send a message "
-                "(subject=%r) to %d recipient(s) -- not fully allowlisted "
-                "and no EMAIL_SAFE_MODE_REDIRECT_TO configured.",
-                message.subject, len(recipients),
+                "AllowlistEmailBackend: refusing to send a message to %d "
+                "recipient(s) -- not fully allowlisted and no "
+                "EMAIL_SAFE_MODE_REDIRECT_TO configured.",
+                len(recipients),
             )
             raise RuntimeError(
                 "AllowlistEmailBackend: a message to {} recipient(s) is not "

--- a/utils/safe_email_backend.py
+++ b/utils/safe_email_backend.py
@@ -15,9 +15,9 @@ message:
 - lets it through unchanged if every recipient (To/Cc/Bcc) is on the
   allowlist (``EMAIL_SAFE_MODE_ALLOWED_DOMAINS`` / ``_ADDRESSES``);
 - otherwise redirects the *whole* message to
-  ``EMAIL_SAFE_MODE_REDIRECT_TO``, with the original recipients recorded in
-  the subject and appended to the body, so a tester can still see what
-  *would* have gone out;
+  ``EMAIL_SAFE_MODE_REDIRECT_TO``, with the original recipients appended to
+  the body (subject stays generic), so a tester can still see what *would*
+  have gone out;
 - refuses to send (raises, rather than silently dropping or silently
   delivering to an unknown address) if a message needs redirecting but no
   ``EMAIL_SAFE_MODE_REDIRECT_TO`` is configured.
@@ -81,12 +81,23 @@ def _bare_address(address):
 
 
 def _is_allowed(address, allowed_domains, allowed_addresses):
-    address = _bare_address(address).strip().lower()
-    if not address:
-        return True  # nothing to protect against an empty recipient slot
-    if address in allowed_addresses:
+    raw = (address or '').strip()
+    if not raw:
+        return True  # nothing to protect against an unused recipient slot
+    parsed = _bare_address(raw).strip().lower()
+    if not parsed:
+        # Non-empty input that parseaddr couldn't extract a clean address
+        # from -- e.g. a malformed compound value like
+        # "real@example.com, ok@allowed.org" parses to ('', ''), which
+        # earlier treated the same as "nothing here" and let it through
+        # unredirected (real fail-open bypass, Codex review round 2,
+        # 2026-08-31, verified live: parseaddr() really does return that).
+        # An unparseable-but-nonempty value is suspicious, not harmless --
+        # fail closed.
+        return False
+    if parsed in allowed_addresses:
         return True
-    domain = address.rsplit('@', 1)[-1] if '@' in address else ''
+    domain = parsed.rsplit('@', 1)[-1] if '@' in parsed else ''
     return bool(domain) and domain in allowed_domains
 
 
@@ -142,21 +153,26 @@ class AllowlistEmailBackend(BaseEmailBackend):
             return message
 
         if not self.redirect_to:
+            # Log at ERROR (not just raise) because Celery's send_mail_task
+            # swallows exceptions from backends without re-raising, which
+            # would otherwise make this look like a silently dropped
+            # email. Deliberately does NOT log the actual recipient
+            # addresses -- that would recreate the exact PII-in-logs
+            # exposure the subject/body split above exists to avoid
+            # (Codex review round 2, 2026-08-31); a count is enough to
+            # know something needs fixing.
             logger.error(
-                "AllowlistEmailBackend: refusing to send a message to %r -- "
-                "not fully allowlisted and no EMAIL_SAFE_MODE_REDIRECT_TO "
-                "configured. Logged at ERROR (not just raised) because "
-                "Celery's send_mail_task swallows exceptions from backends "
-                "without re-raising, which would otherwise make this look "
-                "like a silently dropped email.",
-                recipients,
+                "AllowlistEmailBackend: refusing to send a message "
+                "(subject=%r) to %d recipient(s) -- not fully allowlisted "
+                "and no EMAIL_SAFE_MODE_REDIRECT_TO configured.",
+                message.subject, len(recipients),
             )
             raise RuntimeError(
-                "AllowlistEmailBackend: message to {!r} is not fully "
-                "allowlisted (EMAIL_SAFE_MODE_ALLOWED_DOMAINS/_ADDRESSES) "
-                "and EMAIL_SAFE_MODE_REDIRECT_TO is not set, so there's "
-                "nowhere safe to send it. Refusing to send rather than "
-                "guess.".format(recipients)
+                "AllowlistEmailBackend: a message to {} recipient(s) is not "
+                "fully allowlisted (EMAIL_SAFE_MODE_ALLOWED_DOMAINS/"
+                "_ADDRESSES) and EMAIL_SAFE_MODE_REDIRECT_TO is not set, so "
+                "there's nowhere safe to send it. Refusing to send rather "
+                "than guess.".format(len(recipients))
             )
 
         redirected = copy.copy(message)
@@ -186,7 +202,8 @@ class AllowlistEmailBackend(BaseEmailBackend):
             raise RuntimeError(
                 "AllowlistEmailBackend: rewriting recipients to the "
                 "redirect target didn't take effect (message.recipients() "
-                "still returns {!r}) -- this message type can't be safely "
-                "redirected. Refusing to send.".format(actual)
+                "still returns {} address(es), not just the redirect "
+                "target) -- this message type can't be safely redirected. "
+                "Refusing to send.".format(len(actual))
             )
         return redirected

--- a/utils/safe_email_backend.py
+++ b/utils/safe_email_backend.py
@@ -1,0 +1,111 @@
+"""Allowlist/redirect email backend for non-production environments.
+
+Any environment whose database might be (or become) a copy of production
+data holds real users' real email addresses. Without this backend, that
+environment's normal Django mail-sending code (password resets, gift
+notices, campaign emails, etc.) would deliver real email to real people --
+exactly what happened on test.unglue.it 2026-08-31 after its database was
+refreshed from a prod snapshot (see regluit#1238).
+
+Enabled by setting ``EMAIL_SAFE_MODE=true`` (see settings/common.py, which
+then points ``EMAIL_BACKEND`` at ``AllowlistEmailBackend`` below). Wraps
+whatever the real backend would otherwise have been and, for each outgoing
+message:
+
+- lets it through unchanged if every recipient (To/Cc/Bcc) is on the
+  allowlist (``EMAIL_SAFE_MODE_ALLOWED_DOMAINS`` / ``_ADDRESSES``);
+- otherwise redirects the *whole* message to
+  ``EMAIL_SAFE_MODE_REDIRECT_TO``, with the original recipients recorded in
+  the subject and appended to the body, so a tester can still see what
+  *would* have gone out;
+- refuses to send (raises, rather than silently dropping or silently
+  delivering to an unknown address) if a message needs redirecting but no
+  ``EMAIL_SAFE_MODE_REDIRECT_TO`` is configured.
+
+Silent dropping is deliberately not an option here -- it's exactly the kind
+of behavior that made two earlier staging-email incidents (regluit#1164,
+regluit-provisioning#22) more confusing to diagnose than they needed to be:
+"nothing happened" looks identical to "it's broken" and to "it's working
+correctly," and no one incident is more common than the others.
+"""
+import copy
+
+from django.conf import settings
+from django.utils.module_loading import import_string
+
+DEFAULT_REAL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+
+
+def _is_allowed(address, allowed_domains, allowed_addresses):
+    address = (address or '').strip().lower()
+    if not address:
+        return True  # nothing to protect against an empty recipient slot
+    if address in allowed_addresses:
+        return True
+    domain = address.rsplit('@', 1)[-1] if '@' in address else ''
+    return bool(domain) and domain in allowed_domains
+
+
+class AllowlistEmailBackend:
+    """Wraps another EMAIL_BACKEND, redirecting non-allowlisted mail."""
+
+    def __init__(self, fail_silently=False, **kwargs):
+        real_backend_path = getattr(
+            settings, 'SAFE_EMAIL_REAL_BACKEND', DEFAULT_REAL_BACKEND
+        )
+        real_backend_cls = import_string(real_backend_path)
+        self.real_backend = real_backend_cls(fail_silently=fail_silently, **kwargs)
+        self.fail_silently = fail_silently
+
+        self.allowed_domains = {
+            d.strip().lower()
+            for d in getattr(settings, 'EMAIL_SAFE_MODE_ALLOWED_DOMAINS', '').split(',')
+            if d.strip()
+        }
+        self.allowed_addresses = {
+            a.strip().lower()
+            for a in getattr(settings, 'EMAIL_SAFE_MODE_ALLOWED_ADDRESSES', '').split(',')
+            if a.strip()
+        }
+        self.redirect_to = getattr(settings, 'EMAIL_SAFE_MODE_REDIRECT_TO', '') or None
+
+    def open(self):
+        return self.real_backend.open()
+
+    def close(self):
+        return self.real_backend.close()
+
+    def send_messages(self, email_messages):
+        if not email_messages:
+            return 0
+        prepared = [self._redirect_if_needed(m) for m in email_messages]
+        return self.real_backend.send_messages(prepared)
+
+    def _redirect_if_needed(self, message):
+        recipients = list(message.to) + list(message.cc) + list(message.bcc)
+        if all(_is_allowed(r, self.allowed_domains, self.allowed_addresses) for r in recipients):
+            return message
+
+        if not self.redirect_to:
+            raise RuntimeError(
+                "AllowlistEmailBackend: message to {!r} is not fully "
+                "allowlisted (EMAIL_SAFE_MODE_ALLOWED_DOMAINS/_ADDRESSES) "
+                "and EMAIL_SAFE_MODE_REDIRECT_TO is not set, so there's "
+                "nowhere safe to send it. Refusing to send rather than "
+                "guess.".format(recipients)
+            )
+
+        redirected = copy.copy(message)
+        original_recipients = ', '.join(recipients) if recipients else '(no recipients)'
+        redirected.to = [self.redirect_to]
+        redirected.cc = []
+        redirected.bcc = []
+        redirected.subject = '[STAGING, would have gone to: {}] {}'.format(
+            original_recipients, message.subject
+        )
+        redirect_note = (
+            '\n\n---\n[Redirected by AllowlistEmailBackend -- this message was '
+            'addressed to: {}]\n'.format(original_recipients)
+        )
+        redirected.body = (message.body or '') + redirect_note
+        return redirected

--- a/utils/safe_email_backend.py
+++ b/utils/safe_email_backend.py
@@ -27,12 +27,22 @@ of behavior that made two earlier staging-email incidents (regluit#1164,
 regluit-provisioning#22) more confusing to diagnose than they needed to be:
 "nothing happened" looks identical to "it's broken" and to "it's working
 correctly," and no one incident is more common than the others.
+
+Deploying this to an actual box (setting EMAIL_SAFE_MODE=true + an
+allowlist/redirect address in its environment, for both the web process AND
+Celery) is a separate, provisioning-side step -- not done by this module
+existing in the codebase. See regluit#1238.
 """
 import copy
+import logging
 import os
+from email.utils import parseaddr
 
 from django.conf import settings
+from django.core.mail.backends.base import BaseEmailBackend
 from django.utils.module_loading import import_string
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_REAL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 ALLOWLIST_BACKEND_PATH = 'regluit.utils.safe_email_backend.AllowlistEmailBackend'
@@ -64,8 +74,14 @@ def resolve_email_backend(email_safe_mode, current_backend, env=None):
     return real_backend, ALLOWLIST_BACKEND_PATH
 
 
+def _bare_address(address):
+    """Extract the bare address from an optional 'Display Name <addr>' form."""
+    _, addr = parseaddr(address or '')
+    return addr
+
+
 def _is_allowed(address, allowed_domains, allowed_addresses):
-    address = (address or '').strip().lower()
+    address = _bare_address(address).strip().lower()
     if not address:
         return True  # nothing to protect against an empty recipient slot
     if address in allowed_addresses:
@@ -74,16 +90,22 @@ def _is_allowed(address, allowed_domains, allowed_addresses):
     return bool(domain) and domain in allowed_domains
 
 
-class AllowlistEmailBackend:
-    """Wraps another EMAIL_BACKEND, redirecting non-allowlisted mail."""
+class AllowlistEmailBackend(BaseEmailBackend):
+    """Wraps another EMAIL_BACKEND, redirecting non-allowlisted mail.
+
+    Subclasses Django's BaseEmailBackend (not a bare object) so it supports
+    everything the real interface promises, including use as a context
+    manager (`with get_connection() as conn: ...`) -- caught missing in CC
+    review, 2026-08-31.
+    """
 
     def __init__(self, fail_silently=False, **kwargs):
+        super().__init__(fail_silently=fail_silently, **kwargs)
         real_backend_path = getattr(
             settings, 'SAFE_EMAIL_REAL_BACKEND', DEFAULT_REAL_BACKEND
         )
         real_backend_cls = import_string(real_backend_path)
         self.real_backend = real_backend_cls(fail_silently=fail_silently, **kwargs)
-        self.fail_silently = fail_silently
 
         self.allowed_domains = {
             d.strip().lower()
@@ -110,11 +132,25 @@ class AllowlistEmailBackend:
         return self.real_backend.send_messages(prepared)
 
     def _redirect_if_needed(self, message):
-        recipients = list(message.to) + list(message.cc) + list(message.bcc)
+        # message.recipients() -- not message.to/.cc/.bcc directly -- is
+        # Django's own authoritative list of who a message actually goes
+        # to; a message subclass can override it to include recipients
+        # that never appear in .to/.cc/.bcc at all. Checking .to/.cc/.bcc
+        # would miss those (CC review, 2026-08-31).
+        recipients = list(message.recipients())
         if all(_is_allowed(r, self.allowed_domains, self.allowed_addresses) for r in recipients):
             return message
 
         if not self.redirect_to:
+            logger.error(
+                "AllowlistEmailBackend: refusing to send a message to %r -- "
+                "not fully allowlisted and no EMAIL_SAFE_MODE_REDIRECT_TO "
+                "configured. Logged at ERROR (not just raised) because "
+                "Celery's send_mail_task swallows exceptions from backends "
+                "without re-raising, which would otherwise make this look "
+                "like a silently dropped email.",
+                recipients,
+            )
             raise RuntimeError(
                 "AllowlistEmailBackend: message to {!r} is not fully "
                 "allowlisted (EMAIL_SAFE_MODE_ALLOWED_DOMAINS/_ADDRESSES) "
@@ -128,12 +164,29 @@ class AllowlistEmailBackend:
         redirected.to = [self.redirect_to]
         redirected.cc = []
         redirected.bcc = []
-        redirected.subject = '[STAGING, would have gone to: {}] {}'.format(
-            original_recipients, message.subject
+        # Deliberately generic subject -- subjects are far more likely than
+        # bodies to end up in SMTP logs, mailbox indexing, or downstream
+        # notifications, so the original recipients (real PII once a box
+        # holds a prod DB copy) go in the body only (CC review, 2026-08-31).
+        redirected.subject = '[STAGING - redirected by AllowlistEmailBackend] {}'.format(
+            message.subject
         )
         redirect_note = (
             '\n\n---\n[Redirected by AllowlistEmailBackend -- this message was '
             'addressed to: {}]\n'.format(original_recipients)
         )
         redirected.body = (message.body or '') + redirect_note
+
+        # Belt-and-suspenders: if message.recipients() is overridden in a
+        # way that setting .to/.cc/.bcc doesn't actually change, refuse to
+        # send rather than assume the rewrite worked (CC review,
+        # 2026-08-31).
+        actual = list(redirected.recipients())
+        if actual != [self.redirect_to]:
+            raise RuntimeError(
+                "AllowlistEmailBackend: rewriting recipients to the "
+                "redirect target didn't take effect (message.recipients() "
+                "still returns {!r}) -- this message type can't be safely "
+                "redirected. Refusing to send.".format(actual)
+            )
         return redirected

--- a/utils/safe_email_backend.py
+++ b/utils/safe_email_backend.py
@@ -29,11 +29,39 @@ regluit-provisioning#22) more confusing to diagnose than they needed to be:
 correctly," and no one incident is more common than the others.
 """
 import copy
+import os
 
 from django.conf import settings
 from django.utils.module_loading import import_string
 
 DEFAULT_REAL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+ALLOWLIST_BACKEND_PATH = 'regluit.utils.safe_email_backend.AllowlistEmailBackend'
+
+
+def resolve_email_backend(email_safe_mode, current_backend, env=None):
+    """Decide what EMAIL_BACKEND (and, when active, what real backend to
+    wrap) a settings module should use, given whether EMAIL_SAFE_MODE is on.
+
+    Pulled out as a plain function -- not inlined in settings/common.py --
+    specifically so it's directly unit-testable. Django's test runner
+    (setup_test_environment) unconditionally overwrites settings.EMAIL_BACKEND
+    with the locmem backend before any TestCase body runs, which means a
+    test that imports django.conf.settings and checks EMAIL_BACKEND from
+    inside a TestCase can never actually observe what settings/common.py
+    computed -- an assertion like that would pass even if this logic were
+    broken (CC review, 2026-08-31, on the first version of this file that
+    inlined the conditional directly in common.py). Testing this function
+    directly, with no settings module or test runner involved, avoids that
+    trap entirely.
+
+    Returns (real_backend_to_wrap, effective_email_backend).
+    """
+    if env is None:
+        env = os.environ
+    if not email_safe_mode:
+        return current_backend, current_backend
+    real_backend = env.get('SAFE_EMAIL_REAL_BACKEND', current_backend)
+    return real_backend, ALLOWLIST_BACKEND_PATH
 
 
 def _is_allowed(address, allowed_domains, allowed_addresses):

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from unittest import mock
 from unittest.mock import MagicMock
@@ -11,6 +12,20 @@ from regluit.utils.safe_email_backend import (
     _is_allowed,
     resolve_email_backend,
 )
+
+
+class TestLoggerNotDisabled(TestCase):
+    def test_safe_email_backend_logger_is_not_disabled(self):
+        # settings/common.py's LOGGING sets disable_existing_loggers=True;
+        # without an explicit 'regluit.utils.safe_email_backend' entry in
+        # LOGGING['loggers'], that silently disables this module's logger
+        # the moment settings/common.py imports it -- meaning the ERROR
+        # log call in _redirect_if_needed() (the one specifically there to
+        # make a Celery-swallowed send-refusal visible) would do nothing.
+        # Verified live and fixed in settings/common.py (Codex review
+        # round 2, 2026-08-31).
+        log = logging.getLogger('regluit.utils.safe_email_backend')
+        self.assertFalse(log.disabled)
 
 
 class TestIsAllowed(TestCase):
@@ -40,6 +55,15 @@ class TestIsAllowed(TestCase):
         # just because of the display-name wrapper (CC review, 2026-08-31).
         self.assertTrue(_is_allowed(
             'Eric Hellman <eric@ebookfoundation.org>', {'ebookfoundation.org'}, set(),
+        ))
+
+    def test_malformed_compound_value_fails_closed(self):
+        # Real bypass found by Codex review round 2, 2026-08-31:
+        # parseaddr("real@example.com, ok@allowed.org") returns ('', '') --
+        # an unparseable non-empty value used to be treated the same as
+        # "no recipient here" and let through. It must fail closed instead.
+        self.assertFalse(_is_allowed(
+            'real@example.com, ok@ebookfoundation.org', {'ebookfoundation.org'}, set(),
         ))
 
 
@@ -153,9 +177,14 @@ class TestAllowlistEmailBackend(TestCase):
         # loudly so the gap gets noticed and configured, not shipped quiet.
         backend = self._backend_with_fake_real()
         msg = EmailMessage(subject='x', body='y', to=['realuser@example.com'])
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(RuntimeError) as ctx:
             backend.send_messages([msg])
         backend.real_backend.send_messages.assert_not_called()
+        # The exception text itself must not carry the real address either
+        # -- a count is enough to diagnose; whatever catches/logs this
+        # exception elsewhere shouldn't become a second PII leak (Codex
+        # review round 2, 2026-08-31).
+        self.assertNotIn('realuser@example.com', str(ctx.exception))
 
     def test_empty_message_list_is_a_noop(self):
         backend = self._backend_with_fake_real()

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -186,6 +186,26 @@ class TestAllowlistEmailBackend(TestCase):
         # review round 2, 2026-08-31).
         self.assertNotIn('realuser@example.com', str(ctx.exception))
 
+    @override_settings(EMAIL_SAFE_MODE_REDIRECT_TO='')
+    def test_refusal_log_line_carries_no_pii(self):
+        # A first-pass fix logged the subject as a "safe" stand-in for the
+        # actual recipient list -- but a subject can itself carry PII
+        # (e.g. "Password reset for real@example.com"), recreating the
+        # exposure the subject/body split exists to avoid. The log record
+        # must carry neither the recipient address nor the subject text
+        # (Codex review round 3, 2026-08-31).
+        backend = self._backend_with_fake_real()
+        msg = EmailMessage(
+            subject='Reset for realuser@example.com',
+            body='y', to=['realuser@example.com'],
+        )
+        with self.assertLogs('regluit.utils.safe_email_backend', level='ERROR') as logs:
+            with self.assertRaises(RuntimeError):
+                backend.send_messages([msg])
+        self.assertEqual(1, len(logs.output))
+        self.assertNotIn('realuser@example.com', logs.output[0])
+        self.assertNotIn('Reset for', logs.output[0])
+
     def test_empty_message_list_is_a_noop(self):
         backend = self._backend_with_fake_real()
         result = backend.send_messages([])

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -1,10 +1,16 @@
+import os
+from unittest import mock
 from unittest.mock import MagicMock
 
-from django.conf import settings
 from django.core.mail import EmailMessage
 from django.test import TestCase, override_settings
 
-from regluit.utils.safe_email_backend import AllowlistEmailBackend, _is_allowed
+from regluit.utils.safe_email_backend import (
+    ALLOWLIST_BACKEND_PATH,
+    AllowlistEmailBackend,
+    _is_allowed,
+    resolve_email_backend,
+)
 
 
 class TestIsAllowed(TestCase):
@@ -109,13 +115,43 @@ class TestAllowlistEmailBackend(TestCase):
         backend.real_backend.send_messages.assert_not_called()
 
 
-class TestEmailSafeModeSettingWiring(TestCase):
-    def test_email_safe_mode_off_by_default(self):
-        # In the test environment EMAIL_SAFE_MODE is not set, so production
-        # (and any environment that hasn't explicitly opted in) must never
-        # accidentally inherit the allowlist backend.
-        self.assertFalse(getattr(settings, 'EMAIL_SAFE_MODE', False))
-        self.assertNotEqual(
-            'regluit.utils.safe_email_backend.AllowlistEmailBackend',
-            settings.EMAIL_BACKEND,
+class TestResolveEmailBackend(TestCase):
+    """Regression guard for settings/common.py's EMAIL_SAFE_MODE wiring.
+
+    This is deliberately NOT a test that imports django.conf.settings and
+    checks EMAIL_BACKEND from inside a TestCase -- Django's test runner
+    (setup_test_environment) unconditionally overwrites
+    settings.EMAIL_BACKEND with the locmem backend before any test body
+    runs, so a check like that would pass even if settings/common.py's
+    conditional were broken (accidentally unconditional, inverted, etc.) --
+    caught in CC review, 2026-08-31. Testing resolve_email_backend()
+    directly, with no settings module involved, is what actually exercises
+    the decision logic settings/common.py delegates to.
+    """
+
+    def test_off_leaves_backend_unchanged(self):
+        real, effective = resolve_email_backend(False, 'some.RealBackend', env={})
+        self.assertEqual('some.RealBackend', real)
+        self.assertEqual('some.RealBackend', effective)
+
+    def test_on_wraps_the_current_backend_by_default(self):
+        real, effective = resolve_email_backend(True, 'some.RealBackend', env={})
+        self.assertEqual('some.RealBackend', real)
+        self.assertEqual(ALLOWLIST_BACKEND_PATH, effective)
+
+    def test_on_honors_an_explicit_real_backend_override(self):
+        real, effective = resolve_email_backend(
+            True, 'some.RealBackend',
+            env={'SAFE_EMAIL_REAL_BACKEND': 'django.core.mail.backends.console.EmailBackend'},
         )
+        self.assertEqual('django.core.mail.backends.console.EmailBackend', real)
+        self.assertEqual(ALLOWLIST_BACKEND_PATH, effective)
+
+    def test_defaults_to_os_environ_when_no_env_passed(self):
+        # settings/common.py calls this with no `env` argument in
+        # production -- confirm that path reads the real process
+        # environment rather than silently doing nothing.
+        with mock.patch.dict(os.environ, {'SAFE_EMAIL_REAL_BACKEND': 'x.RealBackend'}):
+            real, effective = resolve_email_backend(True, 'some.RealBackend')
+        self.assertEqual('x.RealBackend', real)
+        self.assertEqual(ALLOWLIST_BACKEND_PATH, effective)

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -35,6 +35,13 @@ class TestIsAllowed(TestCase):
         # 'ebookfoundation.org' via a loose substring check.
         self.assertFalse(_is_allowed('x@notebookfoundation.org', {'ebookfoundation.org'}, set()))
 
+    def test_display_name_form_is_parsed(self):
+        # "Person <addr>" must match on the bare address, not fail closed
+        # just because of the display-name wrapper (CC review, 2026-08-31).
+        self.assertTrue(_is_allowed(
+            'Eric Hellman <eric@ebookfoundation.org>', {'ebookfoundation.org'}, set(),
+        ))
+
 
 @override_settings(
     EMAIL_SAFE_MODE_ALLOWED_DOMAINS='ebookfoundation.org,gluejar.com',
@@ -71,7 +78,6 @@ class TestAllowlistEmailBackend(TestCase):
         backend.send_messages([msg])
         sent = backend.real_backend.send_messages.call_args[0][0]
         self.assertEqual(['staging-catchall@ebookfoundation.org'], sent[0].to)
-        self.assertIn('realuser@example.com', sent[0].subject)
         self.assertIn('realuser@example.com', sent[0].body)
         # The original message object passed in by calling code is never
         # mutated -- only the copy handed to the real backend is changed.
@@ -87,7 +93,7 @@ class TestAllowlistEmailBackend(TestCase):
         sent = backend.real_backend.send_messages.call_args[0][0]
         self.assertEqual(['staging-catchall@ebookfoundation.org'], sent[0].to)
 
-    def test_cc_and_bcc_are_checked_too(self):
+    def test_cc_is_checked_too(self):
         backend = self._backend_with_fake_real()
         msg = EmailMessage(
             subject='Notice', body='body', to=['someone@ebookfoundation.org'],
@@ -97,6 +103,49 @@ class TestAllowlistEmailBackend(TestCase):
         sent = backend.real_backend.send_messages.call_args[0][0]
         self.assertEqual(['staging-catchall@ebookfoundation.org'], sent[0].to)
         self.assertEqual([], sent[0].cc)
+
+    def test_bcc_is_checked_too(self):
+        backend = self._backend_with_fake_real()
+        msg = EmailMessage(
+            subject='Notice', body='body', to=['someone@ebookfoundation.org'],
+            bcc=['realuser@example.com'],
+        )
+        backend.send_messages([msg])
+        sent = backend.real_backend.send_messages.call_args[0][0]
+        self.assertEqual(['staging-catchall@ebookfoundation.org'], sent[0].to)
+        self.assertEqual([], sent[0].bcc)
+
+    def test_subject_stays_generic_pii_goes_in_body_only(self):
+        # Subjects are far more likely than bodies to end up in SMTP logs
+        # or mailbox indexing -- the real recipient must not appear there
+        # (CC review, 2026-08-31).
+        backend = self._backend_with_fake_real()
+        msg = EmailMessage(subject='Password reset', body='click here', to=['realuser@example.com'])
+        backend.send_messages([msg])
+        sent = backend.real_backend.send_messages.call_args[0][0]
+        self.assertNotIn('realuser@example.com', sent[0].subject)
+        self.assertIn('realuser@example.com', sent[0].body)
+
+    def test_overridden_recipients_that_bypass_to_cc_bcc_are_caught(self):
+        # A message subclass could override recipients() to include an
+        # address that never appears in .to/.cc/.bcc at all -- checking
+        # only .to/.cc/.bcc would let it straight through unredirected.
+        # Real bypass found by CC review, 2026-08-31; fixed by checking
+        # message.recipients() instead.
+        class SneakyMessage(EmailMessage):
+            def recipients(self):
+                return list(super().recipients()) + ['hidden-real@example.com']
+
+        backend = self._backend_with_fake_real()
+        msg = SneakyMessage(subject='Notice', body='body', to=['someone@ebookfoundation.org'])
+        # The hidden hardcoded recipient can't be cleared by setting
+        # .to/.cc/.bcc (recipients() is overridden to always add it back),
+        # so the belt-and-suspenders post-rewrite check must refuse to
+        # send it at all rather than pass it through as if it had been
+        # safely redirected.
+        with self.assertRaises(RuntimeError):
+            backend.send_messages([msg])
+        backend.real_backend.send_messages.assert_not_called()
 
     @override_settings(EMAIL_SAFE_MODE_REDIRECT_TO='')
     def test_refuses_to_send_without_a_redirect_target(self):
@@ -113,6 +162,15 @@ class TestAllowlistEmailBackend(TestCase):
         result = backend.send_messages([])
         self.assertEqual(0, result)
         backend.real_backend.send_messages.assert_not_called()
+
+    def test_usable_as_a_context_manager(self):
+        # Subclassing BaseEmailBackend (not a bare object) is what makes
+        # `with backend:` work at all -- the previous version raised
+        # TypeError here (CC review, 2026-08-31).
+        backend = self._backend_with_fake_real()
+        with backend as conn:
+            self.assertIs(backend, conn)
+        backend.real_backend.close.assert_called()
 
 
 class TestResolveEmailBackend(TestCase):

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -1,0 +1,121 @@
+from unittest.mock import MagicMock
+
+from django.conf import settings
+from django.core.mail import EmailMessage
+from django.test import TestCase, override_settings
+
+from regluit.utils.safe_email_backend import AllowlistEmailBackend, _is_allowed
+
+
+class TestIsAllowed(TestCase):
+    def test_allowed_domain(self):
+        self.assertTrue(_is_allowed('someone@ebookfoundation.org', {'ebookfoundation.org'}, set()))
+
+    def test_allowed_address(self):
+        self.assertTrue(_is_allowed('raymond.yee@gmail.com', set(), {'raymond.yee@gmail.com'}))
+
+    def test_not_allowed(self):
+        self.assertFalse(_is_allowed('realuser@example.com', {'ebookfoundation.org'}, set()))
+
+    def test_case_insensitive(self):
+        self.assertTrue(_is_allowed('Someone@EbookFoundation.ORG', {'ebookfoundation.org'}, set()))
+
+    def test_empty_address_is_harmless(self):
+        # Nothing to protect against an unused To/Cc/Bcc slot.
+        self.assertTrue(_is_allowed('', {'ebookfoundation.org'}, set()))
+
+    def test_domain_confusion_not_allowed(self):
+        # 'notebookfoundation.org' must not match an allowlisted
+        # 'ebookfoundation.org' via a loose substring check.
+        self.assertFalse(_is_allowed('x@notebookfoundation.org', {'ebookfoundation.org'}, set()))
+
+
+@override_settings(
+    EMAIL_SAFE_MODE_ALLOWED_DOMAINS='ebookfoundation.org,gluejar.com',
+    EMAIL_SAFE_MODE_ALLOWED_ADDRESSES='raymond.yee@gmail.com',
+    EMAIL_SAFE_MODE_REDIRECT_TO='staging-catchall@ebookfoundation.org',
+)
+class TestAllowlistEmailBackend(TestCase):
+    """Regression guard for regluit#1238: a staging box whose DB is a copy
+    of production must never deliver real email to real users. Constructing
+    AllowlistEmailBackend() is safe in a test even with the real SMTP
+    backend as its default wrapped class -- Django's SMTP backend doesn't
+    open a socket until send_messages()/open() is actually called, and
+    every test here swaps in a MagicMock before calling send_messages().
+    """
+
+    def _backend_with_fake_real(self):
+        backend = AllowlistEmailBackend()
+        backend.real_backend = MagicMock()
+        backend.real_backend.send_messages.return_value = 1
+        return backend
+
+    def test_fully_allowlisted_message_passes_through_unchanged(self):
+        backend = self._backend_with_fake_real()
+        msg = EmailMessage(subject='Hi', body='body', to=['someone@ebookfoundation.org'])
+        backend.send_messages([msg])
+        sent = backend.real_backend.send_messages.call_args[0][0]
+        self.assertEqual(1, len(sent))
+        self.assertIs(sent[0], msg)
+        self.assertEqual(['someone@ebookfoundation.org'], sent[0].to)
+
+    def test_non_allowlisted_message_is_redirected(self):
+        backend = self._backend_with_fake_real()
+        msg = EmailMessage(subject='Password reset', body='click here', to=['realuser@example.com'])
+        backend.send_messages([msg])
+        sent = backend.real_backend.send_messages.call_args[0][0]
+        self.assertEqual(['staging-catchall@ebookfoundation.org'], sent[0].to)
+        self.assertIn('realuser@example.com', sent[0].subject)
+        self.assertIn('realuser@example.com', sent[0].body)
+        # The original message object passed in by calling code is never
+        # mutated -- only the copy handed to the real backend is changed.
+        self.assertEqual(['realuser@example.com'], msg.to)
+
+    def test_mixed_allowlisted_and_real_recipients_still_redirects(self):
+        backend = self._backend_with_fake_real()
+        msg = EmailMessage(
+            subject='Notice', body='body',
+            to=['someone@ebookfoundation.org', 'realuser@example.com'],
+        )
+        backend.send_messages([msg])
+        sent = backend.real_backend.send_messages.call_args[0][0]
+        self.assertEqual(['staging-catchall@ebookfoundation.org'], sent[0].to)
+
+    def test_cc_and_bcc_are_checked_too(self):
+        backend = self._backend_with_fake_real()
+        msg = EmailMessage(
+            subject='Notice', body='body', to=['someone@ebookfoundation.org'],
+            cc=['realuser@example.com'],
+        )
+        backend.send_messages([msg])
+        sent = backend.real_backend.send_messages.call_args[0][0]
+        self.assertEqual(['staging-catchall@ebookfoundation.org'], sent[0].to)
+        self.assertEqual([], sent[0].cc)
+
+    @override_settings(EMAIL_SAFE_MODE_REDIRECT_TO='')
+    def test_refuses_to_send_without_a_redirect_target(self):
+        # No silent drop, no silent send to an unknown address -- fail
+        # loudly so the gap gets noticed and configured, not shipped quiet.
+        backend = self._backend_with_fake_real()
+        msg = EmailMessage(subject='x', body='y', to=['realuser@example.com'])
+        with self.assertRaises(RuntimeError):
+            backend.send_messages([msg])
+        backend.real_backend.send_messages.assert_not_called()
+
+    def test_empty_message_list_is_a_noop(self):
+        backend = self._backend_with_fake_real()
+        result = backend.send_messages([])
+        self.assertEqual(0, result)
+        backend.real_backend.send_messages.assert_not_called()
+
+
+class TestEmailSafeModeSettingWiring(TestCase):
+    def test_email_safe_mode_off_by_default(self):
+        # In the test environment EMAIL_SAFE_MODE is not set, so production
+        # (and any environment that hasn't explicitly opted in) must never
+        # accidentally inherit the allowlist backend.
+        self.assertFalse(getattr(settings, 'EMAIL_SAFE_MODE', False))
+        self.assertNotEqual(
+            'regluit.utils.safe_email_backend.AllowlistEmailBackend',
+            settings.EMAIL_BACKEND,
+        )


### PR DESCRIPTION
**[CC]** Release to production:

- #1241 — login double-submit guard (fixes #1240: CSRF 403 when a password manager auto-submits the login form; `CC+Codex+LGTM`, 4 review rounds, verified live on test.unglue.it by RY)
- #1239 — opt-in `AllowlistEmailBackend` (#1238; inert on production — `EMAIL_SAFE_MODE` defaults off)

Deploy: code-only (`deploy.yml -e run_collectstatic=true`) — no migrations, no settings render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EqzfARuryr6m6jzGscgAY6
