### PR TITLE
Add a persistent Donate link to the sitewide footer (#1229)

### DIFF
--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -142,6 +142,7 @@
             <li><a href="https://blog.unglue.it">Blog</a></li>
             <li><a href="{% url 'press' %}">Press</a></li>
             <li><a href="http://eepurl.com/fKLfI">Newsletter</a></li>
+            <li><a href="{% url 'newdonation' %}">Donate</a></li>
         </ul>
     </div>
     <div class="column">

--- a/frontend/tests.py
+++ b/frontend/tests.py
@@ -490,17 +490,30 @@ class DonateFooterLinkTests(TestCase):
     (rather than any one page template) gives it a persistent, global
     affordance for logged-in and anonymous visitors alike."""
 
+    def _donate_links_in_footer(self, content):
+        # Codex review of PR #1248: scope the assertion to the footer
+        # (rather than a bare substring search anywhere in the page) and
+        # confirm the link's accessible text, not just its href.
+        from bs4 import BeautifulSoup
+        soup = BeautifulSoup(content, 'html.parser')
+        footer = soup.find(id='footer')
+        self.assertIsNotNone(footer, "page has no #footer element")
+        return footer.find_all('a', href='/payment/donation/create')
+
     def test_footer_has_donate_link_on_a_logged_out_page(self):
         r = Client().get("/privacy/")
         self.assertEqual(r.status_code, 200)
-        content = str(r.content, 'utf-8')
-        self.assertIn('href="/payment/donation/create"', content)
+        links = self._donate_links_in_footer(str(r.content, 'utf-8'))
+        self.assertEqual(len(links), 1)
+        self.assertEqual(links[0].get_text(strip=True), 'Donate')
 
     def test_footer_donate_link_present_on_the_donation_form_itself(self):
         # The chain (fund_the_pledge.html -> basepledge.html ->
         # registration_base.html -> base.html) means the donation form page
-        # renders the same shared footer, not a stripped-down one.
+        # renders the same shared footer, not a stripped-down one. Also
+        # guards against an accidental login redirect swallowing the page.
         r = Client().get("/payment/donation/create")
         self.assertEqual(r.status_code, 200)
-        content = str(r.content, 'utf-8')
-        self.assertIn('href="/payment/donation/create"', content)
+        links = self._donate_links_in_footer(str(r.content, 'utf-8'))
+        self.assertEqual(len(links), 1)
+        self.assertEqual(links[0].get_text(strip=True), 'Donate')

--- a/frontend/tests.py
+++ b/frontend/tests.py
@@ -480,3 +480,27 @@ class LoginDoubleSubmitGuardTests(TestCase):
             result.returncode, 0,
             "guard behavioral tests failed:\n%s\n%s" % (result.stdout, result.stderr),
         )
+
+
+class DonateFooterLinkTests(TestCase):
+    """#1229: the donation form (/payment/donation/create) had no
+    navigation path leading to it anywhere in the site chrome. base.html's
+    sitewide footer is shared by every page in the base.html/
+    registration_base.html/basepledge.html chain, so a single link there
+    (rather than any one page template) gives it a persistent, global
+    affordance for logged-in and anonymous visitors alike."""
+
+    def test_footer_has_donate_link_on_a_logged_out_page(self):
+        r = Client().get("/privacy/")
+        self.assertEqual(r.status_code, 200)
+        content = str(r.content, 'utf-8')
+        self.assertIn('href="/payment/donation/create"', content)
+
+    def test_footer_donate_link_present_on_the_donation_form_itself(self):
+        # The chain (fund_the_pledge.html -> basepledge.html ->
+        # registration_base.html -> base.html) means the donation form page
+        # renders the same shared footer, not a stripped-down one.
+        r = Client().get("/payment/donation/create")
+        self.assertEqual(r.status_code, 200)
+        content = str(r.content, 'utf-8')
+        self.assertIn('href="/payment/donation/create"', content)


### PR DESCRIPTION
## Summary

Fixes #1229: the donation form (`/payment/donation/create`) had no navigation path leading to it anywhere in the site chrome — RY, a logged-in, motivated, site-expert donor, never organically found it.

- One new `<li>` in `frontend/templates/base.html`'s sitewide footer ("About Unglue.it" column), linking `{% url 'newdonation' %}`. `base.html` roots the template chain used by essentially every page (`registration_base.html` → `base.html`; `basepledge.html` → `registration_base.html` → `base.html`; the donation form itself, `fund_the_pledge.html` → `basepledge.html`), so this one edit gives Donate a persistent, sitewide affordance instead of adding it page-by-page.
- The route (`NewDonationView`) has no `login_required`, so it works for anonymous and logged-in visitors alike.
- Only the General Fund exists post-#1230, so there's no two-fund choice left for this link to resolve — the issue's second bullet is already moot.
- Template-only change, screenshot-free per scope — verified with tests instead.

## Test plan
- [x] `DonateFooterLinkTests.test_footer_has_donate_link_on_a_logged_out_page` — GETs `/privacy/` (anonymous), asserts the footer contains `href="/payment/donation/create"`.
- [x] `DonateFooterLinkTests.test_footer_donate_link_present_on_the_donation_form_itself` — confirms the donation form page itself renders the same shared footer.
- [x] Verified both tests fail without the template change (`git stash`ed `base.html`, reran, restored).
- [x] Full `frontend` suite (39 tests) holds at the pre-existing 3-failure baseline (unrelated `RhPageTests` csrfmatch failures) — zero net-new failures.

— rdhyee + Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHjXjrfha4X6TTSzY5obUZ