### PR TITLE
Release: #1247 Stripe donor fix (master → production)

### DIFF
--- a/payment/stripelib.py
+++ b/payment/stripelib.py
@@ -650,10 +650,17 @@ class Processor(baseprocessor.Processor):
 
             # ASSUMPTION:  a user has any given moment one and only one active payment Account
             if token:
-                # user is anonymous
+                # A token means we need to create a new Stripe Customer -- but
+                # that doesn't mean the user is anonymous (#1125): a logged-in
+                # user entering fresh card details for a one-off donation also
+                # arrives with a token. Pass transaction.user through (it's
+                # None for genuinely anonymous transactions) so make_account
+                # labels the Stripe Customer correctly and links the new
+                # Account back to the user's profile instead of always
+                # falling into the anonymous branch.
                 try:
                     account = transaction.get_payment_class().make_account(
-                        token=token, email=transaction.receipt)
+                        user=transaction.user, token=token, email=transaction.receipt)
                 except StripelibError as e:
                     self.errorMessage = str(e)
                     return

--- a/payment/tests.py
+++ b/payment/tests.py
@@ -529,20 +529,37 @@ class AnonymousStripeCustomerBugTest(TestCase):
         user = User.objects.create_user(
             'donor_1125', 'donor_1125@example.org', 'payment_test')
         t = self._make_transaction(user)
+        # A Stripe.js-token-shaped string (as FundView actually passes --
+        # the raw dict-of-card-fields shape is only used by the legacy
+        # live-API test elsewhere in this file), so the
+        # create_customer/create_charge assertions below mean something.
+        # Not a real credential -- StripeClient is fully mocked below.
+        card_ref = 'card-ref-test-1125'
 
         with mock.patch.object(stripelib, "StripeClient") as sc:
             sc.return_value.create_customer.return_value = self._fake_customer()
             sc.return_value.create_charge.return_value.id = 'ch_test_1125'
             pm = PaymentManager()
-            pm.charge(t, token={
-                "number": "4242424242424242", "exp_month": 1, "exp_year": 2030})
+            pm.charge(t, token=card_ref)
 
         _, kwargs = sc.return_value.create_customer.call_args
+        self.assertEqual(kwargs.get('card'), card_ref)
         self.assertEqual(kwargs.get('description'), user.username)
         self.assertEqual(kwargs.get('email'), user.email)
 
         account = Account.objects.get(account_id='cus_test_1125')
         self.assertEqual(account.user, user)
+
+        # Codex round-1 (#1247): a failure after Customer creation must not
+        # go unnoticed -- pin down that the charge actually landed on the
+        # Customer this call just created, and that the transaction is
+        # left fully complete.
+        _, charge_kwargs = sc.return_value.create_charge.call_args
+        self.assertEqual(charge_kwargs.get('customer'), 'cus_test_1125')
+
+        t.refresh_from_db()
+        self.assertEqual(t.status, TRANSACTION_STATUS_COMPLETE)
+        self.assertEqual(t.pay_key, 'ch_test_1125')
 
     def test_truly_anonymous_donation_still_anonymous(self):
         """No transaction.user at all -- must keep the pre-existing

--- a/payment/tests.py
+++ b/payment/tests.py
@@ -477,3 +477,94 @@ class StripeWebhookCourtesyEmailTest(TestCase):
                 response = stripelib.Processor().ProcessIPN(self._post_event())
         self.assertEqual(response.status_code, 200)
         self.assertEqual(sent.call_count, 1)
+
+
+class AnonymousStripeCustomerBugTest(TestCase):
+    """#1125: a logged-in donor's Stripe Customer must not be created as
+    'anonymous user'.
+
+    Reproduces FundView.form_valid's actual call shape for a one-off
+    donation: transaction.user is set to the authenticated donor, but a
+    Stripe.js card token is still passed through to
+    PaymentManager.charge(..., token=...) because the donor doesn't have an
+    Account yet. Pay.__init__ used to key off token-presence alone to decide
+    "user is anonymous", so it called make_account() without the user and
+    every such donation produced a Stripe Customer described as "anonymous
+    user" with no Account linked back to the donor's profile.
+
+    Uses this repo's mocked-Stripe pattern (see StripeWebhookCourtesyEmailTest
+    above) rather than a live call to the Stripe test-mode API.
+    """
+
+    def _fake_customer(self, customer_id='cus_test_1125'):
+        customer = mock.MagicMock()
+        customer.id = customer_id
+        customer.active_card.last4 = '4242'
+        customer.active_card.type = 'Visa'
+        customer.active_card.exp_month = 1
+        customer.active_card.exp_year = 2030
+        customer.active_card.fingerprint = 'fp_test_1125'
+        customer.active_card.country = 'US'
+        return customer
+
+    def _make_transaction(self, user):
+        # No campaign -- this mirrors FundView.form_valid's plain-donation
+        # branch (`if not self.transaction.campaign:`), the actual code path
+        # #1125 was filed against.
+        t = Transaction(host='stripelib')
+        t.max_amount = D('5.00')
+        t.type = PAYMENT_TYPE_NONE
+        t.status = TRANSACTION_STATUS_NONE
+        t.campaign = None
+        t.approved = False
+        t.user = user
+        t.save()
+        return t
+
+    def test_logged_in_donation_creates_identified_customer(self):
+        """Mirrors FundView.form_valid: transaction.user is the authenticated
+        donor AND a token is passed to charge() (no Account exists yet)."""
+        from regluit.payment import stripelib
+
+        user = User.objects.create_user(
+            'donor_1125', 'donor_1125@example.org', 'payment_test')
+        t = self._make_transaction(user)
+
+        with mock.patch.object(stripelib, "StripeClient") as sc:
+            sc.return_value.create_customer.return_value = self._fake_customer()
+            sc.return_value.create_charge.return_value.id = 'ch_test_1125'
+            pm = PaymentManager()
+            pm.charge(t, token={
+                "number": "4242424242424242", "exp_month": 1, "exp_year": 2030})
+
+        _, kwargs = sc.return_value.create_customer.call_args
+        self.assertEqual(kwargs.get('description'), user.username)
+        self.assertEqual(kwargs.get('email'), user.email)
+
+        account = Account.objects.get(account_id='cus_test_1125')
+        self.assertEqual(account.user, user)
+
+    def test_truly_anonymous_donation_still_anonymous(self):
+        """No transaction.user at all -- must keep the pre-existing
+        anonymous-customer behavior (email from transaction.receipt, no
+        Account.user)."""
+        from regluit.payment import stripelib
+
+        t = self._make_transaction(user=None)
+        t.receipt = 'anon_1125@example.org'
+        t.save()
+
+        with mock.patch.object(stripelib, "StripeClient") as sc:
+            sc.return_value.create_customer.return_value = self._fake_customer(
+                customer_id='cus_test_1125_anon')
+            sc.return_value.create_charge.return_value.id = 'ch_test_1125_anon'
+            pm = PaymentManager()
+            pm.charge(t, token={
+                "number": "4242424242424242", "exp_month": 1, "exp_year": 2030})
+
+        _, kwargs = sc.return_value.create_customer.call_args
+        self.assertEqual(kwargs.get('description'), 'anonymous user')
+        self.assertEqual(kwargs.get('email'), 'anon_1125@example.org')
+
+        account = Account.objects.get(account_id='cus_test_1125_anon')
+        self.assertIsNone(account.user)

--- a/payment/tests.py
+++ b/payment/tests.py
@@ -542,6 +542,7 @@ class AnonymousStripeCustomerBugTest(TestCase):
             pm = PaymentManager()
             pm.charge(t, token=card_ref)
 
+        sc.return_value.create_customer.assert_called_once()
         _, kwargs = sc.return_value.create_customer.call_args
         self.assertEqual(kwargs.get('card'), card_ref)
         self.assertEqual(kwargs.get('description'), user.username)
@@ -554,6 +555,7 @@ class AnonymousStripeCustomerBugTest(TestCase):
         # go unnoticed -- pin down that the charge actually landed on the
         # Customer this call just created, and that the transaction is
         # left fully complete.
+        sc.return_value.create_charge.assert_called_once()
         _, charge_kwargs = sc.return_value.create_charge.call_args
         self.assertEqual(charge_kwargs.get('customer'), 'cus_test_1125')
 


### PR DESCRIPTION
Release to production: #1247 (logged-in donors linked to their Stripe Customer, fixes #1125).

`production` already contains everything on `master` up to `51ea4fb7`, so this brings in only the #1247 merge (`51339d6e`): a one-line change in `payment/stripelib.py` plus its tests. There are no migrations, dependency changes or static-asset changes, so the code-only `deploy.yml` is enough.

**Checked on test.unglue.it (running master @ `51339d6e`) on 2026-09-10.** A logged-in, Stripe test-mode donation:
- Transaction 16687: status `Complete`, `user` set.
- New `Account` 3611: `ACTIVE`, `user` set. Its Stripe test-mode Customer's description is the donor's username, not "anonymous user", which was the #1125 bug.

— unglueit-0910 (Claude, for rdhyee)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjPGJQCBFvZ1D2fJgJQpe4
